### PR TITLE
[feature] 한 전시회에 대한 캘린더에 저장된 개인의 일정 날짜 조회 로직 구현

### DIFF
--- a/src/main/java/klieme/artdiary/exhibitions/data_access/entity/ExhEntity.java
+++ b/src/main/java/klieme/artdiary/exhibitions/data_access/entity/ExhEntity.java
@@ -1,5 +1,7 @@
 package klieme.artdiary.exhibitions.data_access.entity;
 
+import java.time.LocalDate;
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -7,8 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
-
-import java.util.Date;
 
 @Entity
 @Table(name = "exhibition")
@@ -21,14 +21,13 @@ public class ExhEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "exh_id", nullable = false)
     private Long exhId;
-
     @Column(name="exh_name",nullable = false)
     private String exhName;
     private String gallery;
     @Column(name="exh_period_start")
-    private Date exhPeriodStart;
+    private LocalDate exhPeriodStart;
     @Column(name="exh_period_end")
-    private Date exhPeriodEnd;
+    private LocalDate exhPeriodEnd;
     private String painter;
     private Integer fee;
     private String intro;
@@ -37,7 +36,8 @@ public class ExhEntity {
     private String poster;
 
     @Builder
-    public ExhEntity(Long exhId,String exhName,String gallery, Date exhPeriodStart, Date exhPeriodEnd, String providerType, String painter, Integer fee,String intro, String url, String poster){
+    public ExhEntity(Long exhId, String exhName, String gallery, LocalDate exhPeriodStart, LocalDate exhPeriodEnd,
+        String painter, Integer fee, String intro, String url, String poster) {
         this.exhId=exhId;
         this.exhName=exhName;
         this.gallery=gallery;

--- a/src/main/java/klieme/artdiary/exhibitions/data_access/entity/UserExhEntity.java
+++ b/src/main/java/klieme/artdiary/exhibitions/data_access/entity/UserExhEntity.java
@@ -1,6 +1,6 @@
 package klieme.artdiary.exhibitions.data_access.entity;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
@@ -28,14 +28,14 @@ public class UserExhEntity {
 	@Column(name = "user_exh_id", nullable = false)
 	private Long userExhId;
 	@Column(name = "visit_date")
-	private Date visitDate;
+	private LocalDate visitDate;
 	@Column(name = "user_id", nullable = false)
 	private Long userId;
 	@Column(name = "exh_id")
 	private Long exhId;
 
 	@Builder
-	public UserExhEntity(Long userExhId, Date visitDate, Long userId, Long exhId) {
+	public UserExhEntity(Long userExhId, LocalDate visitDate, Long userId, Long exhId) {
 		this.userExhId = userExhId;
 		this.visitDate = visitDate;
 		this.userId = userId;

--- a/src/main/java/klieme/artdiary/exhibitions/data_access/repository/UserExhRepository.java
+++ b/src/main/java/klieme/artdiary/exhibitions/data_access/repository/UserExhRepository.java
@@ -1,6 +1,6 @@
 package klieme.artdiary.exhibitions.data_access.repository;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,6 +12,7 @@ import klieme.artdiary.exhibitions.data_access.entity.UserExhEntity;
 @Repository
 public interface UserExhRepository extends JpaRepository<UserExhEntity, Long> {
 	List<UserExhEntity> findByUserIdAndExhId(Long userId, Long exhId);
-	Optional<UserExhEntity> findByUserIdAndExhIdAndVisitDate(Long userId, Long exhId, Date visitDate);
+
+	Optional<UserExhEntity> findByUserIdAndExhIdAndVisitDate(Long userId, Long exhId, LocalDate visitDate);
 
 }

--- a/src/main/java/klieme/artdiary/exhibitions/service/ExhOperationUseCase.java
+++ b/src/main/java/klieme/artdiary/exhibitions/service/ExhOperationUseCase.java
@@ -5,7 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 public interface ExhOperationUseCase {
 
@@ -18,8 +18,8 @@ public interface ExhOperationUseCase {
     class ExhDummyCreateCommand {
         private final String exhName;
         private final String gallery;
-        private final Date exhPeriodStart;
-        private final Date exhPeriodEnd;
+        private final LocalDate exhPeriodStart;
+        private final LocalDate exhPeriodEnd;
         private final String painter;
         private final Integer fee;
         private final String intro;
@@ -33,7 +33,7 @@ public interface ExhOperationUseCase {
     @Getter
     @ToString
     class AddSoloExhDummyCreateCommand {
-        private final Date visitDate;
+        private final LocalDate visitDate;
         private final Long exhId;
 
 

--- a/src/main/java/klieme/artdiary/exhibitions/service/ExhReadUseCase.java
+++ b/src/main/java/klieme/artdiary/exhibitions/service/ExhReadUseCase.java
@@ -1,6 +1,6 @@
 package klieme.artdiary.exhibitions.service;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import lombok.Builder;
@@ -25,10 +25,10 @@ public interface ExhReadUseCase {
 	@Builder
 	class FindStoredDateResult {
 		private final Long exhId;
-		private final Date visitDate; // 단일 데이터일 때 사용
-		private final List<Date> dates; // 리스트 데이터일 떄 사용
+		private final LocalDate visitDate; // 단일 데이터일 때 사용
+		private final List<LocalDate> dates; // 리스트 데이터일 떄 사용
 
-		public static FindStoredDateResult findByStoredDate(Long exhId, Date visitDate, List<Date> dates) {
+		public static FindStoredDateResult findByStoredDate(Long exhId, LocalDate visitDate, List<LocalDate> dates) {
 			return FindStoredDateResult.builder()
 				.exhId(exhId)
 				.visitDate(visitDate)

--- a/src/main/java/klieme/artdiary/exhibitions/service/ExhService.java
+++ b/src/main/java/klieme/artdiary/exhibitions/service/ExhService.java
@@ -5,89 +5,92 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
 import klieme.artdiary.common.ArtDiaryException;
 import klieme.artdiary.common.MessageType;
 import klieme.artdiary.exhibitions.data_access.entity.ExhEntity;
 import klieme.artdiary.exhibitions.data_access.entity.UserExhEntity;
 import klieme.artdiary.exhibitions.data_access.repository.ExhRepository;
 import klieme.artdiary.exhibitions.data_access.repository.UserExhRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 @Service
 public class ExhService implements ExhOperationUseCase, ExhReadUseCase {
 
-    private final ExhRepository exhRepository;
-    private final UserExhRepository userExhRepository;
+	private final ExhRepository exhRepository;
+	private final UserExhRepository userExhRepository;
 
-    @Autowired
-    public ExhService(ExhRepository exhRepository, UserExhRepository userExhRepository) {
-        this.exhRepository = exhRepository;
-        this.userExhRepository = userExhRepository;
-    }
+	@Autowired
+	public ExhService(ExhRepository exhRepository, UserExhRepository userExhRepository) {
+		this.exhRepository = exhRepository;
+		this.userExhRepository = userExhRepository;
+	}
 
-    @Override
-    public String createDummy(ExhOperationUseCase.ExhDummyCreateCommand command) {
-        ExhEntity entity = ExhEntity.builder()
-                .exhName(command.getExhName())
-                .gallery(command.getGallery())
-                .exhPeriodStart(command.getExhPeriodStart())
-                .exhPeriodEnd(command.getExhPeriodEnd())
-                .painter(command.getPainter())
-                .fee(command.getFee())
-                .intro(command.getIntro())
-                .url(command.getUrl())
-                .poster(command.getPoster())
-                .build();
-        exhRepository.save(entity);
-        return "complete";
-    }
+	@Override
+	public String createDummy(ExhOperationUseCase.ExhDummyCreateCommand command) {
+		ExhEntity entity = ExhEntity.builder()
+			.exhName(command.getExhName())
+			.gallery(command.getGallery())
+			.exhPeriodStart(command.getExhPeriodStart())
+			.exhPeriodEnd(command.getExhPeriodEnd())
+			.painter(command.getPainter())
+			.fee(command.getFee())
+			.intro(command.getIntro())
+			.url(command.getUrl())
+			.poster(command.getPoster())
+			.build();
+		exhRepository.save(entity);
+		return "complete";
+	}
 
-    @Override
-    public FindStoredDateResult addSoloExhCreateDummy(ExhOperationUseCase.AddSoloExhDummyCreateCommand command) {
-        // 전시회 아이디 검증
-        ExhEntity exhEntity = exhRepository.findByExhId(command.getExhId())
-            .orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
+	@Override
+	public FindStoredDateResult addSoloExhCreateDummy(ExhOperationUseCase.AddSoloExhDummyCreateCommand command) {
+		// 전시회 아이디 검증
+		ExhEntity exhEntity = exhRepository.findByExhId(command.getExhId())
+			.orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
 
-        // 관람날짜 검증
-        Optional<UserExhEntity> userexhEntity = userExhRepository.findByUserIdAndExhIdAndVisitDate(getUserId(),
-            command.getExhId(), command.getVisitDate());
+		// 관람날짜 검증
+		Optional<UserExhEntity> userExhEntity = userExhRepository.findByUserIdAndExhIdAndVisitDate(getUserId(),
+			command.getExhId(), command.getVisitDate());
 
-        if (userexhEntity.isPresent()) {
-            throw new ArtDiaryException(MessageType.CONFLICT);
-        }
-        // DB에 데이터 생성
-        UserExhEntity entity = UserExhEntity.builder()
-                .visitDate(command.getVisitDate())
-                .userId(getUserId())
-                .exhId(command.getExhId())
-                .build();
-        userExhRepository.save(entity);
-        return FindStoredDateResult.findByStoredDate(command.getExhId(),command.getVisitDate(), null);
-    }
+		if (userExhEntity.isPresent()) {
+			throw new ArtDiaryException(MessageType.CONFLICT);
+		}
 
-    @Override
-    public FindStoredDateResult getStoredDateOfExhs(StoredDateFindQuery query) {
-        // 캘린더에 개인이 저장한 전시회 관람 날짜
-        // userId: getUserId(), exhId: query.getExhId()
-        Long userId = getUserId();
-        List<LocalDate> dates = new ArrayList<>();
+		// DB에 데이터 생성
+		UserExhEntity entity = UserExhEntity.builder()
+			.visitDate(command.getVisitDate())
+			.userId(getUserId())
+			.exhId(command.getExhId())
+			.build();
+		userExhRepository.save(entity);
+		return FindStoredDateResult.findByStoredDate(command.getExhId(), command.getVisitDate(), null);
+	}
 
-        // 전시회 아이디 검증
-        ExhEntity exhEntity = exhRepository.findByExhId(query.getExhId())
-            .orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
+	@Override
+	public FindStoredDateResult getStoredDateOfExhs(StoredDateFindQuery query) {
+		// userId: getUserId(), exhId: query.getExhId(), gatherId: query.getGatherId()
+		Long userId = getUserId();
+		List<LocalDate> dates = new ArrayList<>();
 
-        if (query.getGatherId() == null) {
-            List<UserExhEntity> entities = userExhRepository.findByUserIdAndExhId(userId, query.getExhId());
-            for (UserExhEntity entity : entities) {
-                dates.add(entity.getVisitDate());
-            }
-        }
-        // 캘린더에 모임이 저장한 전시회 관람 날짜
-        return FindStoredDateResult.findByStoredDate(query.getExhId(), null, dates);
-    }
+		// 전시회 아이디 검증
+		exhRepository.findByExhId(query.getExhId()).orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
 
-    private Long getUserId() {
-        return 4L;
-    }
+		if (query.getGatherId() == null) {
+			// (목적) 한 전시회에 대한 캘린더에 저장된 개인의 일정 날짜 조회 로직 구현
+			List<UserExhEntity> entities = userExhRepository.findByUserIdAndExhId(userId, query.getExhId());
+			for (UserExhEntity entity : entities) {
+				if (entity.getVisitDate() == null) { // 날짜 모름일 때는 건너뜀.
+					continue;
+				}
+				dates.add(entity.getVisitDate());
+			}
+		}
+		return FindStoredDateResult.findByStoredDate(query.getExhId(), null, dates);
+	}
+
+	private Long getUserId() {
+		return 4L;
+	}
 }

--- a/src/main/java/klieme/artdiary/exhibitions/ui/request_body/AddSoloExhRequest.java
+++ b/src/main/java/klieme/artdiary/exhibitions/ui/request_body/AddSoloExhRequest.java
@@ -1,14 +1,17 @@
 package klieme.artdiary.exhibitions.ui.request_body;
 
+import java.time.LocalDate;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 @NoArgsConstructor
 public class AddSoloExhRequest {
 
-    public Date visitDate;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    public LocalDate visitDate;
 
 }

--- a/src/main/java/klieme/artdiary/exhibitions/ui/request_body/ExhRequest.java
+++ b/src/main/java/klieme/artdiary/exhibitions/ui/request_body/ExhRequest.java
@@ -1,10 +1,11 @@
 package klieme.artdiary.exhibitions.ui.request_body;
 
+import java.time.LocalDate;
+
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
 
 @Getter
 @NoArgsConstructor
@@ -17,10 +18,10 @@ public class ExhRequest {
     private String gallery;
 
     @NotNull
-    private Date exhPeriodStart;
+    private LocalDate exhPeriodStart;
 
     @NotNull
-    private Date exhPeriodEnd;
+    private LocalDate exhPeriodEnd;
 
     @NotNull
     private String painter;

--- a/src/main/java/klieme/artdiary/exhibitions/ui/view/StoredDateView.java
+++ b/src/main/java/klieme/artdiary/exhibitions/ui/view/StoredDateView.java
@@ -1,6 +1,6 @@
 package klieme.artdiary.exhibitions.ui.view;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -15,8 +15,8 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StoredDateView {
 	private final Long exhId;
-	private final Date visitDate;
-	private final List<Date> dates;
+	private final LocalDate visitDate;
+	private final List<LocalDate> dates;
 
 	@Builder
 	public StoredDateView(ExhReadUseCase.FindStoredDateResult result) {


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #15
<br/>

## ⚙️ 변경 사항 

한 전시회에 대한 캘린더에 저장된 개인의 일정 날짜 조회 로직 중 visitDate가 null인 경우 제외 구현

<br/>

## 💦 변경한 이유

- 한 전시회에 대한 캘린더에 저장된 개인의 일정 날짜 조회 로직 중 visitDate가 null인 경우 제외 구현

- exh service 파일에 코딩 컨벤션 적용

- date 클래스 대신 localdate 클래스 사용으로 대체

     - 두 클래스의 날짜 형식이 다름.
     - date를 사용했을 때 원하는 결과가 나오지 않아 원하는 날짜 형식을 맞추려면 코드 길이가 길어지고 가독성이 나빠짐.
     - localdate로 바꾼 후, 원하는 날짜 형식을 바로 사용할 수 있었음. 
     - 또한 앞으로 날짜 비교할 일이 있을 때 localdate 클래스의 함수를 사용하여 편하게 날짜 비교가 가능할 것으로 예상.

<br/>

## 💻 테스트 사항

- postman

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
