### PR TITLE
Feature/30 feature 모임의 캘린더에 전시회 관람 일정 추가 기능 구현 (포스터 및 별점 데이터 구현 제외)

### DIFF
--- a/src/main/java/klieme/artdiary/common/MessageType.java
+++ b/src/main/java/klieme/artdiary/common/MessageType.java
@@ -11,6 +11,7 @@ public enum MessageType {
 	INTERNAL_SERVER_ERROR("An error occurred inside the server.", HttpStatus.INTERNAL_SERVER_ERROR),
 	CONFLICT("Already exists data.", HttpStatus.CONFLICT),
 	FORBIDDEN("Do not have an authorization.", HttpStatus.FORBIDDEN),
+	FORBIDDEN_DATE("It's not the day.", HttpStatus.FORBIDDEN),
 	ExpiredJwtException("Access Token is expired.", HttpStatus.UNAUTHORIZED),
 	UNAUTHORIZED("You can use it after login.", HttpStatus.UNAUTHORIZED),
 	UsernameOrPasswordNotFound("Not existed user.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/klieme/artdiary/exhibitions/service/ExhService.java
+++ b/src/main/java/klieme/artdiary/exhibitions/service/ExhService.java
@@ -58,6 +58,12 @@ public class ExhService implements ExhOperationUseCase, ExhReadUseCase {
 			throw new ArtDiaryException(MessageType.CONFLICT);
 		}
 
+		// 전시회 일정에 맞춰 갈 수 있는지 확인
+		if (exhEntity.getExhPeriodStart().isAfter(command.getVisitDate())
+			|| exhEntity.getExhPeriodEnd().isBefore(command.getVisitDate())) {
+			throw new ArtDiaryException(MessageType.FORBIDDEN_DATE);
+		}
+
 		// DB에 데이터 생성
 		UserExhEntity entity = UserExhEntity.builder()
 			.visitDate(command.getVisitDate())
@@ -87,6 +93,9 @@ public class ExhService implements ExhOperationUseCase, ExhReadUseCase {
 				dates.add(entity.getVisitDate());
 			}
 		}
+		/* TODO
+		 * (목적) 한 전시회에 대한 캘린더에 저장된 모임의 일정 날짜 조회 로직 구현 필요
+		 */
 		return FindStoredDateResult.findByStoredDate(query.getExhId(), null, dates);
 	}
 

--- a/src/main/java/klieme/artdiary/gatherings/data_access/entity/GatheringExhEntity.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/entity/GatheringExhEntity.java
@@ -1,0 +1,44 @@
+package klieme.artdiary.gatherings.data_access.entity;
+
+import java.time.LocalDate;
+
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "gathering_exh")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
+@DynamicUpdate
+public class GatheringExhEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "gathering_exh_id", nullable = false)
+	private Long gatheringExhId;
+	@Column(name = "visit_date")
+	private LocalDate visitDate;
+	@Column(name = "gather_id", nullable = false)
+	private Long gatherId;
+	@Column(name = "exh_id")
+	private Long exhId;
+
+	@Builder
+	public GatheringExhEntity(Long gatheringExhId, LocalDate visitDate, Long gatherId, Long exhId) {
+		this.gatheringExhId = gatheringExhId;
+		this.visitDate = visitDate;
+		this.gatherId = gatherId;
+		this.exhId = exhId;
+	}
+}

--- a/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringExhRepository.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringExhRepository.java
@@ -1,0 +1,17 @@
+package klieme.artdiary.gatherings.data_access.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import klieme.artdiary.gatherings.data_access.entity.GatheringExhEntity;
+
+@Repository
+public interface GatheringExhRepository extends JpaRepository<GatheringExhEntity, Long> {
+	Optional<GatheringExhEntity> findByGatherIdAndExhIdAndVisitDate(Long gatherId, Long exhId, LocalDate visitDate);
+
+	List<GatheringExhEntity> findByGatherId(Long gatherId);
+}

--- a/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringMateRepository.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringMateRepository.java
@@ -1,15 +1,11 @@
 package klieme.artdiary.gatherings.data_access.repository;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
-
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import klieme.artdiary.exhibitions.data_access.entity.UserExhEntity;
 import klieme.artdiary.gatherings.data_access.entity.GatheringMateEntity;
 import klieme.artdiary.gatherings.data_access.entity.GatheringMateId;
 
@@ -17,5 +13,6 @@ import klieme.artdiary.gatherings.data_access.entity.GatheringMateId;
 public interface GatheringMateRepository extends JpaRepository<GatheringMateEntity, GatheringMateId> {
 
 	List<GatheringMateEntity> findByGatheringMateIdUserId(Long userId);
+
 	Optional<GatheringMateEntity> findByGatheringMateId(GatheringMateId gatheringMateId);
 }

--- a/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringMateRepository.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringMateRepository.java
@@ -1,5 +1,7 @@
 package klieme.artdiary.gatherings.data_access.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +10,5 @@ import klieme.artdiary.gatherings.data_access.entity.GatheringMateId;
 
 @Repository
 public interface GatheringMateRepository extends JpaRepository<GatheringMateEntity, GatheringMateId> {
+	Optional<GatheringMateEntity> findByGatheringMateId(GatheringMateId gatheringMateId);
 }

--- a/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringRepository.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringRepository.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import klieme.artdiary.exhibitions.data_access.entity.ExhEntity;
 import klieme.artdiary.gatherings.data_access.entity.GatheringEntity;
 
 @Repository

--- a/src/main/java/klieme/artdiary/gatherings/service/GatheringOperationUseCase.java
+++ b/src/main/java/klieme/artdiary/gatherings/service/GatheringOperationUseCase.java
@@ -1,5 +1,8 @@
 package klieme.artdiary.gatherings.service;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -9,11 +12,23 @@ public interface GatheringOperationUseCase {
 
 	GatheringReadUseCase.FindGatheringResult createGathering(GatheringCreateCommand command);
 
+	List<GatheringReadUseCase.FindGatheringExhsResult> addExhAboutGathering(ExhGatheringCreateCommand command);
+
 	@EqualsAndHashCode
 	@Builder
 	@Getter
 	@ToString
 	class GatheringCreateCommand {
 		private final String gatherName;
+	}
+
+	@EqualsAndHashCode
+	@Builder
+	@Getter
+	@ToString
+	class ExhGatheringCreateCommand {
+		private final Long gatherId;
+		private final Long exhId;
+		private final LocalDate visitDate;
 	}
 }

--- a/src/main/java/klieme/artdiary/gatherings/service/GatheringReadUseCase.java
+++ b/src/main/java/klieme/artdiary/gatherings/service/GatheringReadUseCase.java
@@ -2,11 +2,9 @@ package klieme.artdiary.gatherings.service;
 
 import java.util.List;
 
-import klieme.artdiary.exhibitions.service.ExhReadUseCase;
 import klieme.artdiary.exhibitions.data_access.entity.ExhEntity;
 import klieme.artdiary.gatherings.data_access.entity.GatheringEntity;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 

--- a/src/main/java/klieme/artdiary/gatherings/service/GatheringReadUseCase.java
+++ b/src/main/java/klieme/artdiary/gatherings/service/GatheringReadUseCase.java
@@ -1,5 +1,6 @@
 package klieme.artdiary.gatherings.service;
 
+import klieme.artdiary.exhibitions.data_access.entity.ExhEntity;
 import klieme.artdiary.gatherings.data_access.entity.GatheringEntity;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,25 @@ public interface GatheringReadUseCase {
 			return FindGatheringResult.builder()
 				.gatherId(entity.getGatherId())
 				.gatherName(entity.getGatherName())
+				.build();
+		}
+	}
+
+	@Getter
+	@ToString
+	@Builder
+	class FindGatheringExhsResult {
+		private final Long exhId;
+		private final String exhName;
+		private final String poster;
+		private final Double rate;
+
+		public static FindGatheringExhsResult findByGatheringExhs(ExhEntity entity, String poster, Double rate) {
+			return FindGatheringExhsResult.builder()
+				.exhId(entity.getExhId())
+				.exhName(entity.getExhName())
+				.poster(poster)
+				.rate(rate)
 				.build();
 		}
 	}

--- a/src/main/java/klieme/artdiary/gatherings/service/GatheringService.java
+++ b/src/main/java/klieme/artdiary/gatherings/service/GatheringService.java
@@ -1,11 +1,21 @@
 package klieme.artdiary.gatherings.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import klieme.artdiary.common.ArtDiaryException;
+import klieme.artdiary.common.MessageType;
+import klieme.artdiary.exhibitions.data_access.entity.ExhEntity;
+import klieme.artdiary.exhibitions.data_access.repository.ExhRepository;
 import klieme.artdiary.gatherings.data_access.entity.GatheringEntity;
+import klieme.artdiary.gatherings.data_access.entity.GatheringExhEntity;
 import klieme.artdiary.gatherings.data_access.entity.GatheringMateEntity;
 import klieme.artdiary.gatherings.data_access.entity.GatheringMateId;
+import klieme.artdiary.gatherings.data_access.repository.GatheringExhRepository;
 import klieme.artdiary.gatherings.data_access.repository.GatheringMateRepository;
 import klieme.artdiary.gatherings.data_access.repository.GatheringRepository;
 
@@ -13,19 +23,26 @@ import klieme.artdiary.gatherings.data_access.repository.GatheringRepository;
 public class GatheringService implements GatheringOperationUseCase {
 	private final GatheringRepository gatheringRepository;
 	private final GatheringMateRepository gatheringMateRepository;
+	private final ExhRepository exhRepository;
+	private final GatheringExhRepository gatheringExhRepository;
 
 	@Autowired
-	public GatheringService(GatheringRepository gatheringRepository, GatheringMateRepository gatheringMateRepository) {
+	public GatheringService(GatheringRepository gatheringRepository, GatheringMateRepository gatheringMateRepository,
+		ExhRepository exhRepository, GatheringExhRepository gatheringExhRepository) {
 		this.gatheringRepository = gatheringRepository;
 		this.gatheringMateRepository = gatheringMateRepository;
+		this.exhRepository = exhRepository;
+		this.gatheringExhRepository = gatheringExhRepository;
 	}
 
 	@Override
 	public GatheringReadUseCase.FindGatheringResult createGathering(GatheringCreateCommand command) {
+		// 모임 생성
 		GatheringEntity gatheringEntity = GatheringEntity.builder()
 			.gatherName(command.getGatherName())
 			.build();
 		gatheringRepository.save(gatheringEntity);
+		// 모임에 유저 추가
 		GatheringMateEntity mateEntity = GatheringMateEntity.builder()
 			.gatheringMateId(GatheringMateId.builder()
 				.gatherId(gatheringEntity.getGatherId())
@@ -33,7 +50,70 @@ public class GatheringService implements GatheringOperationUseCase {
 				.build())
 			.build();
 		gatheringMateRepository.save(mateEntity);
+		// 반환
 		return GatheringReadUseCase.FindGatheringResult.findByGathering(gatheringEntity);
+	}
+
+	@Override
+	public List<GatheringReadUseCase.FindGatheringExhsResult> addExhAboutGathering(ExhGatheringCreateCommand command) {
+		// 유저가 속한 모임의 gatherId인지 확인
+		gatheringMateRepository.findByGatheringMateId(GatheringMateId.builder()
+			.gatherId(command.getGatherId())
+			.userId(getUserId())
+			.build()).orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
+
+		// exhId 존재하는 전시회 아이디인지 확인
+		ExhEntity storedExhEntity = exhRepository.findByExhId(command.getExhId())
+			.orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
+
+		// 모임에 이미 저장된 날짜인지 확인
+		Optional<GatheringExhEntity> storedGatheringExhEntity = gatheringExhRepository.findByGatherIdAndExhIdAndVisitDate(
+			command.getGatherId(), command.getExhId(), command.getVisitDate());
+
+		if (storedGatheringExhEntity.isPresent()) {
+			throw new ArtDiaryException(MessageType.CONFLICT);
+		}
+
+		// 전시회 일정에 맞춰 갈 수 있는지 확인
+		if (storedExhEntity.getExhPeriodStart().isAfter(command.getVisitDate())
+			|| storedExhEntity.getExhPeriodEnd().isBefore(command.getVisitDate())) {
+			throw new ArtDiaryException(MessageType.FORBIDDEN_DATE);
+		}
+
+		// 모임의 일정에 추가
+		GatheringExhEntity addGatheringExhEntity = GatheringExhEntity.builder()
+			.visitDate(command.getVisitDate())
+			.gatherId(command.getGatherId())
+			.exhId(command.getExhId())
+			.build();
+
+		gatheringExhRepository.save(addGatheringExhEntity);
+
+		/* 반환 - 모임의 전시회 리스트 */
+		List<GatheringReadUseCase.FindGatheringExhsResult> result = new ArrayList<>();
+		// 모임이 저장한 전시회 리스트 요청
+		List<GatheringExhEntity> gatheringExhEntityList = gatheringExhRepository.findByGatherId(command.getGatherId());
+		// 같은 전시회지만 방문 날짜가 다른 경우를 중복을 없애기 위해 사용
+		List<Long> checkExhs = new ArrayList<>();
+
+		for (GatheringExhEntity entity : gatheringExhEntityList) {
+			if (!checkExhs.contains(entity.getExhId())) { // 이미 얻은 전시회인지 확인
+				// 전시회 정보 조회
+				Optional<ExhEntity> exh = exhRepository.findByExhId(entity.getExhId());
+				if (exh.isPresent()) {
+					/* TODO
+					 * 저장된 포스터 사진 있으면 구현
+					 * 전시회 별점 - 개인 + 모임들의 별점 합산 => 기록이 있어야 함.
+					 * 아래 코드의 null 수정 필요
+					 */
+					// 포스터 사진
+					// 전시회 별점 - 개인 + 모임들의 별점 합산 => 기록이 있어야 함.
+					result.add(GatheringReadUseCase.FindGatheringExhsResult.findByGatheringExhs(exh.get(), null, null));
+				}
+				checkExhs.add(entity.getExhId());
+			}
+		}
+		return result;
 	}
 
 	private Long getUserId() {

--- a/src/main/java/klieme/artdiary/gatherings/service/GatheringService.java
+++ b/src/main/java/klieme/artdiary/gatherings/service/GatheringService.java
@@ -2,17 +2,11 @@ package klieme.artdiary.gatherings.service;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import klieme.artdiary.common.ArtDiaryException;
-import klieme.artdiary.common.MessageType;
-import klieme.artdiary.exhibitions.service.ExhReadUseCase;
 import klieme.artdiary.common.ArtDiaryException;
 import klieme.artdiary.common.MessageType;
 import klieme.artdiary.exhibitions.data_access.entity.ExhEntity;

--- a/src/main/java/klieme/artdiary/gatherings/ui/controller/GatheringController.java
+++ b/src/main/java/klieme/artdiary/gatherings/ui/controller/GatheringController.java
@@ -10,12 +10,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
-import klieme.artdiary.exhibitions.service.ExhReadUseCase;
-import klieme.artdiary.exhibitions.ui.view.StoredDateView;
 import klieme.artdiary.gatherings.service.GatheringOperationUseCase;
 import klieme.artdiary.gatherings.service.GatheringReadUseCase;
 import klieme.artdiary.gatherings.ui.request_body.AddExhDateRequest;
@@ -28,7 +25,6 @@ import klieme.artdiary.gatherings.ui.view.GatheringView;
 public class GatheringController {
 	private final GatheringOperationUseCase gatheringOperationUseCase;
 	private final GatheringReadUseCase gatheringReadUseCase;
-
 
 	@Autowired
 	public GatheringController(GatheringOperationUseCase gatheringOperationUseCase,

--- a/src/main/java/klieme/artdiary/gatherings/ui/controller/GatheringController.java
+++ b/src/main/java/klieme/artdiary/gatherings/ui/controller/GatheringController.java
@@ -1,7 +1,11 @@
 package klieme.artdiary.gatherings.ui.controller;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,7 +14,9 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import klieme.artdiary.gatherings.service.GatheringOperationUseCase;
 import klieme.artdiary.gatherings.service.GatheringReadUseCase;
+import klieme.artdiary.gatherings.ui.request_body.AddExhDateRequest;
 import klieme.artdiary.gatherings.ui.request_body.AddGatheringRequest;
+import klieme.artdiary.gatherings.ui.view.GatheringExhView;
 import klieme.artdiary.gatherings.ui.view.GatheringView;
 
 @RestController
@@ -25,10 +31,36 @@ public class GatheringController {
 
 	@PostMapping("")
 	public ResponseEntity<GatheringView> createGathering(@Valid @RequestBody AddGatheringRequest request) {
+		// request body 데이터 받아오기
 		var command = GatheringOperationUseCase.GatheringCreateCommand.builder()
 			.gatherName(request.getGatherName())
 			.build();
+		// 비즈니스 로직 호출
 		GatheringReadUseCase.FindGatheringResult result = gatheringOperationUseCase.createGathering(command);
+		// 비즈니스 로직 결과값을 view 형식에 맞춰 반환
 		return ResponseEntity.created(null).body(GatheringView.builder().result(result).build());
+	}
+
+	@PostMapping("/{gatherId}/exhibitions")
+	public ResponseEntity<List<GatheringExhView>> addExhAboutGathering(
+		@PathVariable(name = "gatherId") Long gatherId,
+		@Valid @RequestBody AddExhDateRequest request
+	) {
+		// request body 데이터 받아오기
+		var command = GatheringOperationUseCase.ExhGatheringCreateCommand.builder()
+			.gatherId(gatherId)
+			.exhId(request.getExhId())
+			.visitDate(request.getVisitDate())
+			.build();
+		// 비즈니스 로직 호출
+		List<GatheringReadUseCase.FindGatheringExhsResult> results = gatheringOperationUseCase.addExhAboutGathering(
+			command);
+		// 비즈니스 로직 결과값을 view 형식에 맞춰 list로 반환
+		List<GatheringExhView> viewResult = new ArrayList<>();
+
+		for (GatheringReadUseCase.FindGatheringExhsResult result : results) {
+			viewResult.add(GatheringExhView.builder().result(result).build());
+		}
+		return ResponseEntity.ok(viewResult);
 	}
 }

--- a/src/main/java/klieme/artdiary/gatherings/ui/request_body/AddExhDateRequest.java
+++ b/src/main/java/klieme/artdiary/gatherings/ui/request_body/AddExhDateRequest.java
@@ -1,0 +1,16 @@
+package klieme.artdiary.gatherings.ui.request_body;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AddExhDateRequest {
+	@NotNull
+	private Long exhId;
+	@NotNull
+	private LocalDate visitDate;
+}

--- a/src/main/java/klieme/artdiary/gatherings/ui/view/GatheringExhView.java
+++ b/src/main/java/klieme/artdiary/gatherings/ui/view/GatheringExhView.java
@@ -1,0 +1,26 @@
+package klieme.artdiary.gatherings.ui.view;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import klieme.artdiary.gatherings.service.GatheringReadUseCase;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GatheringExhView {
+	private final Long exhId;
+	private final String exhName;
+	private final String poster;
+	private final Double rate;
+
+	@Builder
+	public GatheringExhView(GatheringReadUseCase.FindGatheringExhsResult result) {
+		this.exhId = result.getExhId();
+		this.exhName = result.getExhName();
+		this.poster = result.getPoster();
+		this.rate = result.getRate();
+	}
+}


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #30 
<br/>

## ⚙️ 변경 사항 

모임의 캘린더에 전시회 관람 일정 추가 기능 구현 (포스터 및 별점 데이터 구현 제외)
+ 전시회에 대한 개인 일정 추가 코드에 전시회 일정에 맞춰 갈 수 있는지 확인하는 코드 추가

<br/>

## 💦 변경한 이유

- 모임의 캘린더에 전시회 관람 일정 추가 기능 구현 (포스터 및 별점 데이터 구현 제외)
- 전시회에 대한 개인 일정 추가 코드에 전시회 일정에 맞춰 갈 수 있는지 확인하는 코드 추가
    - 전시회 일정을 벗어난 날짜로 관람할 수 없도록 추가

<br/>

## 💻 테스트 사항

- postman 사용

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
