### PR TITLE
[refactor] 모임에서 작성한 자신의 기록 조회 쿼리 수 줄이면서 검증 과정이 짧아짐.

### DIFF
--- a/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringDiaryRepository.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringDiaryRepository.java
@@ -10,4 +10,6 @@ import klieme.artdiary.gatherings.data_access.entity.GatheringDiaryEntity;
 @Repository
 public interface GatheringDiaryRepository extends JpaRepository<GatheringDiaryEntity, Long> {
 	List<GatheringDiaryEntity> findByGatheringExhId(Long gatheringExhId);
+
+	List<GatheringDiaryEntity> findByUserId(Long userId);
 }


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #40 
<br/>

## ⚙️ 변경 사항 

기록 추가 기능 중 모임에서 작성한 자신의 기록 조회 방법 변경

<br/>

## 💦 변경한 이유

- 모임에서 자신이 작성한 기록인지 필터링하는 부분이 없었음.
- gathering_diary 엔티티의 userId를 활용하여 gathering_diary부터 검증하는 방법을 선택하면서 디비에 요청하는 쿼리의 수가 1개 줄면서 코드 길이도 줄어들었음.

<br/>

## 💻 테스트 사항

- postman 사용

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
