### PR TITLE
Refactor/55 refactor equals 사용 수정 및 디비 업데이트 데이터 비교 위치 변경

### DIFF
--- a/src/main/java/klieme/artdiary/gatherings/data_access/entity/GatheringDiaryEntity.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/entity/GatheringDiaryEntity.java
@@ -61,12 +61,12 @@ public class GatheringDiaryEntity {
 
 	public void updateDiary(String title, Double rate, Boolean diaryPrivate, String contents, String thumbnail,
 		LocalDate writeDate, String saying) {
-		this.title = title;
-		this.rate = rate;
-		this.diaryPrivate = diaryPrivate;
-		this.contents = contents;
-		this.thumbnail = thumbnail;
-		this.writeDate = writeDate;
-		this.saying = saying;
+		this.title = title.equals(this.title) ? this.title : title;
+		this.rate = rate.equals(this.rate) ? this.rate : rate;
+		this.diaryPrivate = diaryPrivate.equals(this.diaryPrivate) ? this.diaryPrivate : diaryPrivate;
+		this.contents = contents.equals(this.contents) ? this.contents : contents;
+		this.thumbnail = thumbnail.equals(this.thumbnail) ? this.thumbnail : thumbnail;
+		this.writeDate = writeDate.equals(this.writeDate) ? this.writeDate : writeDate;
+		this.saying = saying.equals(this.saying) ? this.saying : saying;
 	}
 }

--- a/src/main/java/klieme/artdiary/gatherings/data_access/entity/GatheringDiaryEntity.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/entity/GatheringDiaryEntity.java
@@ -59,14 +59,14 @@ public class GatheringDiaryEntity {
 		this.gatheringExhId = gatheringExhId;
 	}
 
-	public void updateDiary(String title, Double rate, Boolean diaryPrivate, String contents, String thumbnail,
-		LocalDate writeDate, String saying) {
-		this.title = title.equals(this.title) ? this.title : title;
-		this.rate = rate.equals(this.rate) ? this.rate : rate;
-		this.diaryPrivate = diaryPrivate.equals(this.diaryPrivate) ? this.diaryPrivate : diaryPrivate;
-		this.contents = contents.equals(this.contents) ? this.contents : contents;
-		this.thumbnail = thumbnail.equals(this.thumbnail) ? this.thumbnail : thumbnail;
-		this.writeDate = writeDate.equals(this.writeDate) ? this.writeDate : writeDate;
-		this.saying = saying.equals(this.saying) ? this.saying : saying;
+	public void updateDiary(GatheringDiaryEntity entity) {
+		this.title = entity.getTitle().equals(this.title) ? this.title : entity.getTitle();
+		this.rate = entity.getRate().equals(this.rate) ? this.rate : entity.getRate();
+		this.diaryPrivate =
+			entity.getDiaryPrivate().equals(this.diaryPrivate) ? this.diaryPrivate : entity.getDiaryPrivate();
+		this.contents = entity.getContents().equals(this.contents) ? this.contents : entity.getContents();
+		this.thumbnail = entity.getThumbnail().equals(this.thumbnail) ? this.thumbnail : entity.getThumbnail();
+		this.writeDate = entity.getWriteDate().equals(this.writeDate) ? this.writeDate : entity.getWriteDate();
+		this.saying = entity.getSaying().equals(this.saying) ? this.saying : entity.getSaying();
 	}
 }

--- a/src/main/java/klieme/artdiary/mydiarys/data_access/entity/MydiaryEntity.java
+++ b/src/main/java/klieme/artdiary/mydiarys/data_access/entity/MydiaryEntity.java
@@ -56,15 +56,14 @@ public class MydiaryEntity {
 		this.userExhId = userExhId;
 	}
 
-	public void updateDiary(String title, Double rate, Boolean diaryPrivate, String contents,
-		String thumbnail, LocalDate writeDate, String saying) {
-		this.title = title.equals(this.title) ? this.title : title;
-		this.rate = rate.equals(this.rate) ? this.rate : rate;
-		this.diaryPrivate = diaryPrivate.equals(this.diaryPrivate) ? this.diaryPrivate : diaryPrivate;
-		this.contents = contents.equals(this.contents) ? this.contents : contents;
-		this.thumbnail = thumbnail.equals(this.thumbnail) ? this.thumbnail : thumbnail;
-		this.writeDate = writeDate.equals(this.writeDate) ? this.writeDate : writeDate;
-		this.saying = saying.equals(this.saying) ? this.saying : saying;
+	public void updateDiary(MydiaryEntity entity) {
+		this.title = entity.getTitle().equals(this.title) ? this.title : entity.getTitle();
+		this.rate = entity.getRate().equals(this.rate) ? this.rate : entity.getRate();
+		this.diaryPrivate =
+			entity.getDiaryPrivate().equals(this.diaryPrivate) ? this.diaryPrivate : entity.getDiaryPrivate();
+		this.contents = entity.getContents().equals(this.contents) ? this.contents : entity.getContents();
+		this.thumbnail = entity.getThumbnail().equals(this.thumbnail) ? this.thumbnail : entity.getThumbnail();
+		this.writeDate = entity.getWriteDate().equals(this.writeDate) ? this.writeDate : entity.getWriteDate();
+		this.saying = entity.getSaying().equals(this.saying) ? this.saying : entity.getSaying();
 	}
-
 }

--- a/src/main/java/klieme/artdiary/mydiarys/data_access/entity/MydiaryEntity.java
+++ b/src/main/java/klieme/artdiary/mydiarys/data_access/entity/MydiaryEntity.java
@@ -58,13 +58,13 @@ public class MydiaryEntity {
 
 	public void updateDiary(String title, Double rate, Boolean diaryPrivate, String contents,
 		String thumbnail, LocalDate writeDate, String saying) {
-		this.title = title;
-		this.rate = rate;
-		this.diaryPrivate = diaryPrivate;
-		this.contents = contents;
-		this.thumbnail = thumbnail;
-		this.writeDate = writeDate;
-		this.saying = saying;
+		this.title = title.equals(this.title) ? this.title : title;
+		this.rate = rate.equals(this.rate) ? this.rate : rate;
+		this.diaryPrivate = diaryPrivate.equals(this.diaryPrivate) ? this.diaryPrivate : diaryPrivate;
+		this.contents = contents.equals(this.contents) ? this.contents : contents;
+		this.thumbnail = thumbnail.equals(this.thumbnail) ? this.thumbnail : thumbnail;
+		this.writeDate = writeDate.equals(this.writeDate) ? this.writeDate : writeDate;
+		this.saying = saying.equals(this.saying) ? this.saying : saying;
 	}
 
 }

--- a/src/main/java/klieme/artdiary/mydiarys/service/MydiaryService.java
+++ b/src/main/java/klieme/artdiary/mydiarys/service/MydiaryService.java
@@ -174,18 +174,8 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 			MydiaryEntity saved = mydiaryRepository.findBySoloDiaryId(command.getDiaryId())
 				.orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
 			// 데이터 수정
-			saved.updateDiary(
-				Objects.equals(saved.getTitle(), command.getTitle()) ? saved.getTitle() : command.getTitle(),
-				Objects.equals(saved.getRate(), command.getRate()) ? saved.getRate() : command.getRate(),
-				Objects.equals(saved.getDiaryPrivate(), command.getDiaryPrivate())
-					? saved.getDiaryPrivate() : command.getDiaryPrivate(),
-				Objects.equals(saved.getContents(), command.getContents())
-					? saved.getContents() : command.getContents(),
-				Objects.equals(saved.getThumbnail(), command.getThumbnail())
-					? saved.getThumbnail() : command.getThumbnail(),
-				Objects.equals(saved.getWriteDate(), command.getWriteDate())
-					? saved.getWriteDate() : command.getWriteDate(),
-				Objects.equals(saved.getSaying(), command.getSaying()) ? saved.getSaying() : command.getSaying());
+			saved.updateDiary(command.getTitle(), command.getRate(), command.getDiaryPrivate(), command.getContents(),
+				command.getThumbnail(), command.getWriteDate(), command.getSaying());
 			mydiaryRepository.save(saved);
 		} else { // 모임
 			// 저장된 데이터 조회
@@ -202,18 +192,8 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 				throw new ArtDiaryException(MessageType.NOT_FOUND);
 			}
 			// 디비에 데이터 수정
-			saved.updateDiary(
-				Objects.equals(saved.getTitle(), command.getTitle()) ? saved.getTitle() : command.getTitle(),
-				Objects.equals(saved.getRate(), command.getRate()) ? saved.getRate() : command.getRate(),
-				Objects.equals(saved.getDiaryPrivate(), command.getDiaryPrivate())
-					? saved.getDiaryPrivate() : command.getDiaryPrivate(),
-				Objects.equals(saved.getContents(), command.getContents())
-					? saved.getContents() : command.getContents(),
-				Objects.equals(saved.getThumbnail(), command.getThumbnail())
-					? saved.getThumbnail() : command.getThumbnail(),
-				Objects.equals(saved.getWriteDate(), command.getWriteDate())
-					? saved.getWriteDate() : command.getWriteDate(),
-				Objects.equals(saved.getSaying(), command.getSaying()) ? saved.getSaying() : command.getSaying());
+			saved.updateDiary(command.getTitle(), command.getRate(), command.getDiaryPrivate(), command.getContents(),
+				command.getThumbnail(), command.getWriteDate(), command.getSaying());
 			gatheringDiaryRepository.save(saved);
 		}
 		return getMyDiaryList(userEntity, exhEntity);

--- a/src/main/java/klieme/artdiary/mydiarys/service/MydiaryService.java
+++ b/src/main/java/klieme/artdiary/mydiarys/service/MydiaryService.java
@@ -3,7 +3,6 @@ package klieme.artdiary.mydiarys.service;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -174,8 +173,15 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 			MydiaryEntity saved = mydiaryRepository.findBySoloDiaryId(command.getDiaryId())
 				.orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
 			// 데이터 수정
-			saved.updateDiary(command.getTitle(), command.getRate(), command.getDiaryPrivate(), command.getContents(),
-				command.getThumbnail(), command.getWriteDate(), command.getSaying());
+			saved.updateDiary(MydiaryEntity.builder()
+				.title(command.getTitle())
+				.rate(command.getRate())
+				.diaryPrivate(command.getDiaryPrivate())
+				.contents(command.getContents())
+				.thumbnail(command.getThumbnail())
+				.writeDate(command.getWriteDate())
+				.saying(command.getSaying())
+				.build());
 			mydiaryRepository.save(saved);
 		} else { // 모임
 			// 저장된 데이터 조회
@@ -192,8 +198,15 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 				throw new ArtDiaryException(MessageType.NOT_FOUND);
 			}
 			// 디비에 데이터 수정
-			saved.updateDiary(command.getTitle(), command.getRate(), command.getDiaryPrivate(), command.getContents(),
-				command.getThumbnail(), command.getWriteDate(), command.getSaying());
+			saved.updateDiary(GatheringDiaryEntity.builder()
+				.title(command.getTitle())
+				.rate(command.getRate())
+				.diaryPrivate(command.getDiaryPrivate())
+				.contents(command.getContents())
+				.thumbnail(command.getThumbnail())
+				.writeDate(command.getWriteDate())
+				.saying(command.getSaying())
+				.build());
 			gatheringDiaryRepository.save(saved);
 		}
 		return getMyDiaryList(userEntity, exhEntity);

--- a/src/main/java/klieme/artdiary/mydiarys/service/MydiaryService.java
+++ b/src/main/java/klieme/artdiary/mydiarys/service/MydiaryService.java
@@ -68,10 +68,8 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 			// userExhId, exhId, userId 검증
 			UserExhEntity storedUserExhEntity = userExhRepository.findByUserExhId(command.getUserExhId())
 				.orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
-			if (!Objects.equals(storedUserExhEntity.getExhId(), command.getExhId())) {
-				throw new ArtDiaryException(MessageType.NOT_FOUND);
-			}
-			if (!Objects.equals(storedUserExhEntity.getUserId(), userEntity.getUserId())) {
+			if (!storedUserExhEntity.getExhId().equals(command.getExhId())
+				|| !storedUserExhEntity.getUserId().equals(userEntity.getUserId())) {
 				throw new ArtDiaryException(MessageType.NOT_FOUND);
 			}
 			// 디비에 데이터 저장
@@ -90,7 +88,7 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 			// gatherExhId, exhId, userId 검증
 			GatheringExhEntity storedGatherExhEntity = gatheringExhRepository.findByGatheringExhId(
 				command.getGatheringExhId()).orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
-			if (!Objects.equals(storedGatherExhEntity.getExhId(), command.getExhId())) {
+			if (!storedGatherExhEntity.getExhId().equals(command.getExhId())) {
 				throw new ArtDiaryException(MessageType.NOT_FOUND);
 			}
 			// 유저가 모임에 속해 있는지 확인
@@ -136,31 +134,28 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 			//userexhId로 user_exh에서 exhid가 가지고 있는 exhId와 맞는지 확인, userId가 userID와 맞는지 확인,마지막으로 solo_diary에서 solodiaryId 삭제
 			UserExhEntity userExhEntity = userExhRepository.findByUserExhId(soloDiaryEntity.getUserExhId())
 				.orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
-			if (Objects.equals(userExhEntity.getExhId(), exhId) && Objects.equals(userExhEntity.getUserId(),
-				getUserId())) {
+			if (userExhEntity.getExhId().equals(exhId) && userExhEntity.getUserId().equals(getUserId())) {
 				mydiaryRepository.delete(soloDiaryEntity);
-
 			} else {
 				throw new ArtDiaryException(MessageType.NOT_FOUND);
 			}
 		} else {//solo=false인 경우
 			//gatering_diary에서 gatherdiaryId와 userId가 가지고 있는 userId가 맞는지 확인
-
 			GatheringDiaryEntity gatheringDiaryEntity = gatheringDiaryRepository.findByGatherDiaryIdAndUserId(diaryId,
 				getUserId()).orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
 			//gatherexhId로 gather_exh에서 exhId가 가지고 있는 exhId가 맞는지 확인, gathering_diary에서 gatehrdiarId 삭제
 			GatheringExhEntity gatheringExhEntity = gatheringExhRepository.findByGatheringExhId(
 					gatheringDiaryEntity.getGatheringExhId())
 				.orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
-			if (Objects.equals(gatheringExhEntity.getExhId(), exhId)) {
+			if (gatheringExhEntity.getExhId().equals(exhId)) {
 				gatheringDiaryRepository.delete(gatheringDiaryEntity);
 			} else {
 				throw new ArtDiaryException(MessageType.NOT_FOUND);
-
 			}
-
 		}
+	}
 
+	@Override
 	public List<FindMyDiaryResult> updateMyDiary(MyDiaryUpdateCommand command) {
 		// user 데이터
 		UserEntity userEntity = getUser();
@@ -171,8 +166,8 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 			// userExhId, exhId, userId 검증
 			UserExhEntity storedUserExhEntity = userExhRepository.findByUserExhId(command.getUserExhId())
 				.orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
-			if (!Objects.equals(storedUserExhEntity.getExhId(), command.getExhId())
-				|| !Objects.equals(storedUserExhEntity.getUserId(), userEntity.getUserId())) {
+			if (!storedUserExhEntity.getExhId().equals(command.getExhId())
+				|| !storedUserExhEntity.getUserId().equals(userEntity.getUserId())) {
 				throw new ArtDiaryException(MessageType.NOT_FOUND);
 			}
 			// 저장된 데이터 조회
@@ -197,13 +192,13 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 			GatheringDiaryEntity saved = gatheringDiaryRepository.findByGatherDiaryIdAndUserId(command.getDiaryId(),
 				userEntity.getUserId()).orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
 			// gatherExhId, userId 검증
-			if (!Objects.equals(saved.getGatheringExhId(), command.getGatheringExhId())) {
+			if (!saved.getGatheringExhId().equals(command.getGatheringExhId())) {
 				throw new ArtDiaryException(MessageType.NOT_FOUND);
 			}
 			// exhId 검증
 			GatheringExhEntity storedGatherExhEntity = gatheringExhRepository.findByGatheringExhId(
 				command.getGatheringExhId()).orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
-			if (!Objects.equals(storedGatherExhEntity.getExhId(), command.getExhId())) {
+			if (!storedGatherExhEntity.getExhId().equals(command.getExhId())) {
 				throw new ArtDiaryException(MessageType.NOT_FOUND);
 			}
 			// 디비에 데이터 수정
@@ -252,8 +247,7 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 			// gathering_exh에서 exhId 걸러내고
 			Optional<GatheringExhEntity> gatheringExhEntity = gatheringExhRepository.findByGatheringExhId(
 				gatheringDiaryEntity.getGatheringExhId());
-			if (gatheringExhEntity.isEmpty()
-				|| !Objects.equals(gatheringExhEntity.get().getExhId(), exhEntity.getExhId())) {
+			if (gatheringExhEntity.isEmpty() || !gatheringExhEntity.get().getExhId().equals(exhEntity.getExhId())) {
 				continue;
 			}
 			// gatherId로 gathering 데이터 가져오기.
@@ -267,5 +261,4 @@ public class MydiaryService implements MydiaryOperationUseCase, MydiaryReadUseCa
 		results.sort(Comparator.comparing(FindMyDiaryResult::getVisitDate));
 		return results;
 	}
-
 }

--- a/src/main/java/klieme/artdiary/myexhs/service/MyExhsReadUseCase.java
+++ b/src/main/java/klieme/artdiary/myexhs/service/MyExhsReadUseCase.java
@@ -1,17 +1,30 @@
 package klieme.artdiary.myexhs.service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import klieme.artdiary.exhibitions.data_access.entity.ExhEntity;
-import klieme.artdiary.gatherings.service.GatheringReadUseCase;
-import klieme.artdiary.mydiarys.data_access.entity.MydiaryEntity;
+import klieme.artdiary.exhibitions.data_access.entity.UserExhEntity;
+import klieme.artdiary.gatherings.data_access.entity.GatheringEntity;
+import klieme.artdiary.gatherings.data_access.entity.GatheringExhEntity;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 public interface MyExhsReadUseCase {
 
 	List<FindMyExhsResult> getMyExhsList();
+
+	List<FindMyStoredDateResult> getStoredDateOfExhs(MyStoredDateFindQuery query);
+
+	@EqualsAndHashCode
+	@Getter
+	@ToString
+	@Builder
+	class MyStoredDateFindQuery {
+		private final Long exhId;
+	}
 
 	@Getter
 	@ToString
@@ -59,7 +72,38 @@ public interface MyExhsReadUseCase {
 
 			// 필드 값을 비교하여 동등 여부를 판단
 			FindMyExhsResult tmp = (FindMyExhsResult)o;
-			return exhId == tmp.exhId;
+			return exhId.equals(tmp.exhId);
+		}
+	}
+
+	@Getter
+	@ToString
+	@Builder
+	class FindMyStoredDateResult {
+		private final Long exhId;
+		private final Long gatherId; // 개인일 경우엔 null
+		private final Long gatheringExhId; // 개인일 경우엔 null
+		private final String gatherName; // 개인일 경우엔 null
+		private final Long userExhId; // 모임일 경우엔 null
+		private final List<LocalDate> dates;
+
+		public static FindMyStoredDateResult findByMyStoredDateSolo(UserExhEntity userExh, List<LocalDate> dates) {
+			return FindMyStoredDateResult.builder()
+				.exhId(userExh.getExhId())
+				.userExhId(userExh.getUserExhId())
+				.dates(dates)
+				.build();
+		}
+
+		public static FindMyStoredDateResult findByMyStoredDateGather(GatheringExhEntity gatheringExh,
+			GatheringEntity gathering, List<LocalDate> dates) {
+			return FindMyStoredDateResult.builder()
+				.exhId(gatheringExh.getExhId())
+				.gatherId(gathering.getGatherId())
+				.gatheringExhId(gatheringExh.getGatheringExhId())
+				.gatherName(gathering.getGatherName())
+				.dates(dates)
+				.build();
 		}
 	}
 }

--- a/src/main/java/klieme/artdiary/myexhs/ui/controller/MyExhsController.java
+++ b/src/main/java/klieme/artdiary/myexhs/ui/controller/MyExhsController.java
@@ -3,16 +3,17 @@ package klieme.artdiary.myexhs.ui.controller;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import klieme.artdiary.gatherings.service.GatheringReadUseCase;
-import klieme.artdiary.gatherings.ui.view.GatheringView;
 import klieme.artdiary.myexhs.service.MyExhsOperationUseCase;
 import klieme.artdiary.myexhs.service.MyExhsReadUseCase;
 import klieme.artdiary.myexhs.ui.view.MyExhsView;
+import klieme.artdiary.myexhs.ui.view.MyStoredDateView;
 
 @RestController
 @RequestMapping(value = "/myexhs")
@@ -20,6 +21,7 @@ public class MyExhsController {
 	private final MyExhsOperationUseCase myExhsOperationUseCase;
 	private final MyExhsReadUseCase myExhsReadUseCase;
 
+	@Autowired
 	public MyExhsController(MyExhsOperationUseCase myExhsOperationUseCase, MyExhsReadUseCase myExhsReadUseCase) {
 		this.myExhsOperationUseCase = myExhsOperationUseCase;
 		this.myExhsReadUseCase = myExhsReadUseCase;
@@ -39,4 +41,17 @@ public class MyExhsController {
 
 	}
 
+	@GetMapping("/{exhId}")
+	public ResponseEntity<List<MyStoredDateView>> getStoredDateOfExhs(@PathVariable(name = "exhId") Long exhId) {
+		var query = MyExhsReadUseCase.MyStoredDateFindQuery.builder().exhId(exhId).build();
+		// 비즈니스 로직 호출
+		List<MyExhsReadUseCase.FindMyStoredDateResult> results = myExhsReadUseCase.getStoredDateOfExhs(query);
+		// 비즈니스 로직 결과값을 view 형식에 맞춰 list로 반환
+		List<MyStoredDateView> viewResult = new ArrayList<>();
+
+		for (MyExhsReadUseCase.FindMyStoredDateResult result : results) {
+			viewResult.add(MyStoredDateView.builder().result(result).build());
+		}
+		return ResponseEntity.ok(viewResult);
+	}
 }

--- a/src/main/java/klieme/artdiary/myexhs/ui/view/MyStoredDateView.java
+++ b/src/main/java/klieme/artdiary/myexhs/ui/view/MyStoredDateView.java
@@ -1,0 +1,33 @@
+package klieme.artdiary.myexhs.ui.view;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import klieme.artdiary.myexhs.service.MyExhsReadUseCase;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MyStoredDateView {
+	private final Long exhId;
+	private final Long gatherId; // 개인일 경우엔 null
+	private final Long gatheringExhId; // 개인일 경우엔 null
+	private final String gatherName; // 개인일 경우엔 null
+	private final Long userExhId; // 모임일 경우엔 null
+	private final List<LocalDate> dates;
+
+	@Builder
+	public MyStoredDateView(MyExhsReadUseCase.FindMyStoredDateResult result) {
+		this.exhId = result.getExhId();
+		this.gatherId = result.getGatherId();
+		this.gatheringExhId = result.getGatheringExhId();
+		this.gatherName = result.getGatherName();
+		this.userExhId = result.getUserExhId();
+		this.dates = result.getDates();
+	}
+}


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #55 
<br/>

## ⚙️ 변경 사항 

equals 사용 수정 및 디비 업데이트 데이터 비교 위치 변경

<br/>

## 💦 변경한 이유

- Objects의 equals를 각 클래스의 equals 사용으로 변경하여 코드 줄 수 줄이고 같은 객체 자료형끼리 비교할 수 있도록 하여 에러 발생 확률을 줄임.
- 디비 데이터 업데이트 하기 전 데이터 비교 위치를 service에서 객체 값을 변경하는 클래스로 이동하여 service 코드에서 가독성을 늘림.

<br/>

## 💻 테스트 사항

- postman 사용

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
