### PR TITLE
[refactor] 캘린더 일정을 일 별이 아닌 월 별로 응답 데이터로 주는 것으로 변경

### DIFF
--- a/src/main/java/klieme/artdiary/calendar/info/ScheduleInfo.java
+++ b/src/main/java/klieme/artdiary/calendar/info/ScheduleInfo.java
@@ -1,0 +1,20 @@
+package klieme.artdiary.calendar.info;
+
+import java.time.LocalDate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ScheduleInfo {
+	private final Long exhId;
+	private final String exhName;
+	private final String gallery;
+	private final LocalDate exhPeriodStart;
+	private final LocalDate exhPeriodEnd;
+	private final String poster;
+	private final LocalDate visitDate;
+	private final Long gatherId; // 개인일 경우 null
+	private final String gatherName; // 개인일 경우 null
+}

--- a/src/main/java/klieme/artdiary/calendar/service/CalendarReadUseCase.java
+++ b/src/main/java/klieme/artdiary/calendar/service/CalendarReadUseCase.java
@@ -1,11 +1,9 @@
 package klieme.artdiary.calendar.service;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import klieme.artdiary.calendar.enums.CalendarKind;
-import klieme.artdiary.exhibitions.data_access.entity.ExhEntity;
-import klieme.artdiary.gatherings.data_access.entity.GatheringEntity;
+import klieme.artdiary.calendar.info.ScheduleInfo;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -21,34 +19,21 @@ public interface CalendarReadUseCase {
 	class CalendarFindQuery {
 		private final CalendarKind kind;
 		private final Long gatherId;
-		private final LocalDate date;
+		private final Integer year;
+		private final Integer month;
 	}
 
 	@Getter
 	@ToString
 	@Builder
 	class FindCalendarResult {
-		private final Long exhId;
-		private final String exhName;
-		private final String gallery;
-		private final LocalDate exhPeriodStart;
-		private final LocalDate exhPeriodEnd;
-		private final String poster;
-		private final LocalDate visitDate;
-		private final Long gatherId; // 개인일 경우 null
-		private final String gatherName; // 개인일 경우 null
+		private final Integer day;
+		private final List<ScheduleInfo> scheduleInfoList;
 
-		public static FindCalendarResult findByCalendar(ExhEntity exh, LocalDate visitDate, String poster,
-			GatheringEntity gathering) {
+		public static FindCalendarResult findByCalendar(Integer day, List<ScheduleInfo> scheduleInfoList) {
 			return FindCalendarResult.builder()
-				.exhId(exh.getExhId())
-				.exhName(exh.getExhName())
-				.exhPeriodStart(exh.getExhPeriodStart())
-				.exhPeriodEnd(exh.getExhPeriodEnd())
-				.poster(poster)
-				.visitDate(visitDate)
-				.gatherId(gathering.getGatherId())
-				.gatherName(gathering.getGatherName())
+				.day(day)
+				.scheduleInfoList(scheduleInfoList)
 				.build();
 		}
 	}

--- a/src/main/java/klieme/artdiary/calendar/ui/controller/CalendarController.java
+++ b/src/main/java/klieme/artdiary/calendar/ui/controller/CalendarController.java
@@ -29,24 +29,32 @@ public class CalendarController {
 
 	/**
 	 * 모임과 날짜 별 저장된 전시회 조회
-	 * "/calendars?kind=[all, alone, gather]&date=[]&gatherId=[]"
+	 * "/calendars?kind=[all, alone, gather]&year=[]&month=[]&gatherId=[]"
 	 */
 	@GetMapping("")
 	public ResponseEntity<List<CalendarView>> getExhSchedule(
 		@RequestParam(name = "kind") String kind,
 		@RequestParam(name = "gatherId", required = false) Long gatherId,
-		@RequestParam(name = "date") LocalDate date
+		@RequestParam(name = "year") Integer year,
+		@RequestParam(name = "month") Integer month
 	) {
 		// 요청 파라미터 검증
 		if ((gatherId == null && CalendarKind.valueOfLabel(kind) == CalendarKind.GATHER)
 			|| (gatherId != null && CalendarKind.valueOfLabel(kind) != CalendarKind.GATHER)) {
 			throw new ArtDiaryException(MessageType.BAD_REQUEST);
 		}
+		// year와 month가 적절한 값이 들어왔는지 확인
+		try {
+			LocalDate targetDate = LocalDate.of(year, month, 1);
+		} catch (Exception e) {
+			throw new ArtDiaryException(MessageType.BAD_REQUEST);
+		}
 		// 파라미터로 받은 데이터 service로 전달하기 위함.
 		var query = CalendarReadUseCase.CalendarFindQuery.builder()
 			.kind(CalendarKind.valueOfLabel(kind))
 			.gatherId(gatherId)
-			.date(date)
+			.year(year)
+			.month(month)
 			.build();
 		// 비즈니스 로직 호출
 		List<CalendarReadUseCase.FindCalendarResult> results = calendarReadUseCase.getExhSchedule(query);

--- a/src/main/java/klieme/artdiary/calendar/ui/view/CalendarView.java
+++ b/src/main/java/klieme/artdiary/calendar/ui/view/CalendarView.java
@@ -1,9 +1,10 @@
 package klieme.artdiary.calendar.ui.view;
 
-import java.time.LocalDate;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import klieme.artdiary.calendar.info.ScheduleInfo;
 import klieme.artdiary.calendar.service.CalendarReadUseCase;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,26 +14,12 @@ import lombok.ToString;
 @ToString
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CalendarView {
-	private final Long exhId;
-	private final String exhName;
-	private final String gallery;
-	private final LocalDate exhPeriodStart;
-	private final LocalDate exhPeriodEnd;
-	private final String poster;
-	private final LocalDate visitDate;
-	private final Long gatherId; // 개인일 경우 null
-	private final String gatherName; // 개인일 경우 null
+	private final Integer day;
+	private final List<ScheduleInfo> scheduleInfoList;
 
 	@Builder
 	public CalendarView(CalendarReadUseCase.FindCalendarResult result) {
-		this.exhId = result.getExhId();
-		this.exhName = result.getExhName();
-		this.gallery = result.getGallery();
-		this.exhPeriodStart = result.getExhPeriodStart();
-		this.exhPeriodEnd = result.getExhPeriodEnd();
-		this.poster = result.getPoster();
-		this.visitDate = result.getVisitDate();
-		this.gatherId = result.getGatherId();
-		this.gatherName = result.getGatherName();
+		this.day = result.getDay();
+		this.scheduleInfoList = result.getScheduleInfoList();
 	}
 }

--- a/src/main/java/klieme/artdiary/exhibitions/data_access/repository/UserExhRepository.java
+++ b/src/main/java/klieme/artdiary/exhibitions/data_access/repository/UserExhRepository.java
@@ -22,5 +22,5 @@ public interface UserExhRepository extends JpaRepository<UserExhEntity, Long> {
 
 	Optional<UserExhEntity> findByUserExhId(Long userExhId);
 
-	List<UserExhEntity> findByUserIdAndVisitDate(Long userId, LocalDate visitDate);
+	List<UserExhEntity> findByUserIdAndVisitDateBetween(Long userId, LocalDate visitDateStart, LocalDate visitDateEnd);
 }

--- a/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringExhRepository.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringExhRepository.java
@@ -21,5 +21,6 @@ public interface GatheringExhRepository extends JpaRepository<GatheringExhEntity
 
 	Optional<GatheringExhEntity> findByGatheringExhId(Long gatheringExhId);
 
-	List<GatheringExhEntity> findByGatherIdAndVisitDate(Long gatherId, LocalDate visitDate);
+	List<GatheringExhEntity> findByGatherIdAndVisitDateBetween(Long gatherId, LocalDate visitDateStart,
+		LocalDate visitDateEnd);
 }


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #96 
<br/>

## ⚙️ 변경 사항 

캘린더 일정을 일 별이 아닌 월 별로 응답 데이터로 주는 것으로 변경

<br/>

## 💦 변경한 이유

- 캘린더 일정을 일 별 요청 보다는 월 별 요청을 통해 요청 확률을 줄여볼 예정

<br/>

## 💻 테스트 사항

- postman 사용

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
