### PR TITLE
[bug] 한 전시회에 대하여 캘린더에 저장된 날짜 조회 응답 데이터 오류 발견

### DIFF
--- a/src/main/java/klieme/artdiary/myexhs/info/StoredDateInfo.java
+++ b/src/main/java/klieme/artdiary/myexhs/info/StoredDateInfo.java
@@ -1,0 +1,14 @@
+package klieme.artdiary.myexhs.info;
+
+import java.time.LocalDate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class StoredDateInfo {
+	private final Long gatheringExhId; // 개인일 경우엔 null
+	private final Long userExhId; // 모임일 경우엔 null
+	private final LocalDate visitDate;
+}

--- a/src/main/java/klieme/artdiary/myexhs/service/MyExhsReadUseCase.java
+++ b/src/main/java/klieme/artdiary/myexhs/service/MyExhsReadUseCase.java
@@ -8,6 +8,7 @@ import klieme.artdiary.exhibitions.data_access.entity.ExhEntity;
 import klieme.artdiary.exhibitions.data_access.entity.UserExhEntity;
 import klieme.artdiary.gatherings.data_access.entity.GatheringEntity;
 import klieme.artdiary.gatherings.data_access.entity.GatheringExhEntity;
+import klieme.artdiary.myexhs.info.StoredDateInfo;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -83,28 +84,27 @@ public interface MyExhsReadUseCase {
 	class FindMyStoredDateResult {
 		private final Long exhId;
 		private final Long gatherId; // 개인일 경우엔 null
-		private final Long gatheringExhId; // 개인일 경우엔 null
+		// private final Long gatheringExhId; // 개인일 경우엔 null
 		private final String gatherName; // 개인일 경우엔 null
+		private final List<StoredDateInfo> dateInfoList;
 		private final Long userExhId; // 모임일 경우엔 null
-		private final List<LocalDate> dates;
-		private final LocalDate date;// 혜원 추가
+		private final LocalDate visitDate;// 혜원 추가
 
-		public static FindMyStoredDateResult findByMyStoredDateSolo(UserExhEntity userExh, List<LocalDate> dates) {
+		public static FindMyStoredDateResult findByMyStoredDateSolo(UserExhEntity userExh,
+			List<StoredDateInfo> dateInfoList) {
 			return FindMyStoredDateResult.builder()
 				.exhId(userExh.getExhId())
-				.userExhId(userExh.getUserExhId())
-				.dates(dates)
+				.dateInfoList(dateInfoList)
 				.build();
 		}
 
 		public static FindMyStoredDateResult findByMyStoredDateGather(GatheringExhEntity gatheringExh,
-			GatheringEntity gathering, List<LocalDate> dates) {
+			GatheringEntity gathering, List<StoredDateInfo> dateInfoList) {
 			return FindMyStoredDateResult.builder()
 				.exhId(gatheringExh.getExhId())
 				.gatherId(gathering.getGatherId())
-				.gatheringExhId(gatheringExh.getGatheringExhId())
 				.gatherName(gathering.getGatherName())
-				.dates(dates)
+				.dateInfoList(dateInfoList)
 				.build();
 		}
 
@@ -112,7 +112,7 @@ public interface MyExhsReadUseCase {
 			return FindMyStoredDateResult.builder()
 				.exhId(userExh.getExhId())
 				.userExhId(userExh.getUserExhId())
-				.date(userExh.getVisitDate())
+				.visitDate(userExh.getVisitDate())
 				.build();
 		}
 

--- a/src/main/java/klieme/artdiary/myexhs/ui/controller/MyExhsController.java
+++ b/src/main/java/klieme/artdiary/myexhs/ui/controller/MyExhsController.java
@@ -80,9 +80,10 @@ public class MyExhsController {
 		List<MyExhsReadUseCase.FindMyStoredDateResult> results = myExhsReadUseCase.getStoredDateOfExhs(query);
 		// 비즈니스 로직 결과값을 view 형식에 맞춰 list로 반환
 		List<MyStoredDateView> viewResult = new ArrayList<>();
+		long index = 0L;
 
 		for (MyExhsReadUseCase.FindMyStoredDateResult result : results) {
-			viewResult.add(MyStoredDateView.builder().result(result).build());
+			viewResult.add(MyStoredDateView.builder().index(index++).result(result).build());
 		}
 		return ResponseEntity.ok(viewResult);
 	}

--- a/src/main/java/klieme/artdiary/myexhs/ui/view/MyStoredDateView.java
+++ b/src/main/java/klieme/artdiary/myexhs/ui/view/MyStoredDateView.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import klieme.artdiary.myexhs.info.StoredDateInfo;
 import klieme.artdiary.myexhs.service.MyExhsReadUseCase;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,20 +15,34 @@ import lombok.ToString;
 @ToString
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MyStoredDateView {
+	private final Long index;
 	private final Long exhId;
 	private final Long gatherId; // 개인일 경우엔 null
-	private final Long gatheringExhId; // 개인일 경우엔 null
 	private final String gatherName; // 개인일 경우엔 null
+	// private final Long gatheringExhId; // 개인일 경우엔 null
 	private final Long userExhId; // 모임일 경우엔 null
-	private final List<LocalDate> dates;
+	private final LocalDate visitDate;
+	private final List<StoredDateInfo> dateInfoList;
+
+	/* 변경된 response data 형식
+	long exhId;
+	long gatherId;
+	string gatherName; (개인일 경우엔 null)
+	date: [
+		long gatheringExhId;
+		long userExhId;
+		localdate visitDate;
+	]
+	*/
 
 	@Builder
-	public MyStoredDateView(MyExhsReadUseCase.FindMyStoredDateResult result) {
+	public MyStoredDateView(Long index, MyExhsReadUseCase.FindMyStoredDateResult result) {
+		this.index = index;
 		this.exhId = result.getExhId();
 		this.gatherId = result.getGatherId();
-		this.gatheringExhId = result.getGatheringExhId();
 		this.gatherName = result.getGatherName();
 		this.userExhId = result.getUserExhId();
-		this.dates = result.getDates();
+		this.visitDate = result.getVisitDate();
+		this.dateInfoList = result.getDateInfoList();
 	}
 }


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #132 
<br/>

## ⚙️ 변경 사항 

한 전시회에 대하여 캘린더에 저장된 날짜 조회 응답 데이터 오류 발견
- 저장된 날짜마다 다른 userExhId를 가지고 있는데 응답 데이터는 날짜 리스트 중 첫번쨰 날짜의 userExhId를 반환하는 오류 발견하여 해결(gatheringExhId도 같은 이유로 해결)

<br/>

## 💦 변경한 이유

- 한 전시회에 대하여 캘린더에 저장된 날짜 조회 응답 데이터 오류 발견

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
