### PR TITLE
[refactor] 전시 메이트의 공개된 기록이 있는 전시회 목록 데이터 요청 시 querydsl 사용으로 변경

### DIFF
--- a/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringRepoCustom.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringRepoCustom.java
@@ -8,7 +8,7 @@ import com.querydsl.core.Tuple;
 
 public interface GatheringRepoCustom {
 
-	List<Map<String, Object>> sumRateByGatherExhId(Long userId);
+	List<Map<String, Object>> sumRateByGatherExhId(Long userId, Boolean withMate);
 
 	List<Tuple> getMyDiaryListInGatheringWithJoin(Long userId, Long exhId);
 

--- a/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringRepoCustomImpl.java
+++ b/src/main/java/klieme/artdiary/gatherings/data_access/repository/GatheringRepoCustomImpl.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -21,10 +22,15 @@ public class GatheringRepoCustomImpl implements GatheringRepoCustom {
 	private final JPAQueryFactory query;
 
 	@Override
-	public List<Map<String, Object>> sumRateByGatherExhId(Long userId) {
+	public List<Map<String, Object>> sumRateByGatherExhId(Long userId, Boolean withMate) {
 		QGatheringDiaryEntity gatheringDiary = QGatheringDiaryEntity.gatheringDiaryEntity;
 		QGatheringExhEntity gatheringExh = QGatheringExhEntity.gatheringExhEntity;
 		QExhEntity exh = QExhEntity.exhEntity;
+		BooleanBuilder builder = new BooleanBuilder();
+
+		if (withMate) {
+			builder.and(gatheringDiary.diaryPrivate.eq(true));
+		}
 
 		List<Tuple> tuples = query
 			.select(gatheringDiary.rate.sum(), gatheringDiary.count(), exh)
@@ -32,7 +38,7 @@ public class GatheringRepoCustomImpl implements GatheringRepoCustom {
 			.leftJoin(gatheringExh).on(gatheringDiary.gatherExhId.eq(gatheringExh.gatherExhId))
 			.leftJoin(exh).on(gatheringExh.exhId.eq(exh.exhId))
 			.fetchJoin()
-			.where(gatheringDiary.userId.eq(userId))
+			.where(gatheringDiary.userId.eq(userId), builder)
 			.groupBy(gatheringExh.exhId)
 			.fetch();
 

--- a/src/main/java/klieme/artdiary/mateexhs/service/MateExhsService.java
+++ b/src/main/java/klieme/artdiary/mateexhs/service/MateExhsService.java
@@ -2,9 +2,10 @@ package klieme.artdiary.mateexhs.service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -66,60 +67,33 @@ public class MateExhsService implements MateExhsReadUseCase {
 
 	@Override
 	public List<FindMateExhsResult> getMateExhsList(MateExhsFindQuery query) throws IOException {
+		Long mateId = query.getMateId();
 		// 내 친구가 맞는지 확인 - exh_mate 확인
-		mateRepository.findByFromUserIdAndToUserId(getUserId(), query.getMateId())
+		mateRepository.findByFromUserIdAndToUserId(getUserId(), mateId)
 			.orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
-		// 친구의 기록이 있는 전시회 조회
-		List<Long> checkExhs = new ArrayList<>(); // 같은 전시회지만 방문 날짜가 다른 경우의 중복을 없애기 위해 사용
-		HashMap<Long, Integer> countDiary = new HashMap<>(); // 전시회에 대한 기록 개수
+		// 1. 전시 메이트가 혼자 방문한 전시회에 대해 작성한 기록이 있는 경우
+		List<Map<String, Object>> myStoredExhList = mydiaryRepository.sumRateByUserExhId(mateId, true);
+		// 2. 전시 메이트가 모임 안에서 방문한 전시회에 대해 작성한 기록이 있는 경우
+		List<Map<String, Object>> myStoredGatherExhList = gatheringRepository.sumRateByGatherExhId(mateId, true);
+
+		//
+		HashMap<Long, Long> countDiary = new HashMap<>(); // 전시회에 대한 기록 개수
 		HashMap<Long, Double> sumDiaryRate = new HashMap<>(); // 전시회에 대한 기록 별점 합
-		// 1. userExh에서 친구가 작성한 기록이 있는 경우
-		List<UserExhEntity> mateExhEntities = userExhRepository.findByUserId(query.getMateId());
-		for (UserExhEntity mateExhEntity : mateExhEntities) {
-			List<MydiaryEntity> mateDiaryEntities = mydiaryRepository.findByUserExhId(mateExhEntity.getUserExhId());
+		HashMap<Long, ExhEntity> exhEntityHashMap = new HashMap<>(); // 전시회에 대한 기록 별점 합
 
-			countDiary.putIfAbsent(mateExhEntity.getExhId(), 0);
-			sumDiaryRate.putIfAbsent(mateExhEntity.getExhId(), 0.0);
-			for (MydiaryEntity mateDiaryEntity : mateDiaryEntities) {
-				Integer countExh = countDiary.get(mateExhEntity.getExhId());
-				Double sumExhRate = sumDiaryRate.get(mateExhEntity.getExhId());
-				countDiary.put(mateExhEntity.getExhId(), countExh + 1);
-				sumDiaryRate.put(mateExhEntity.getExhId(), sumExhRate + mateDiaryEntity.getRate());
-			}
-			// 전시회 중복 제거
-			if (!checkExhs.contains(mateExhEntity.getExhId())) {
-				checkExhs.add(mateExhEntity.getExhId());
-			}
-		}
-		// 2. gatheringDiary애서 userId를 통해 친구가 작성한 기록이 있는 경우
-		List<GatheringDiaryEntity> gatheringDiaryEntities = gatheringDiaryRepository.findByUserId(query.getMateId());
-		for (GatheringDiaryEntity gatheringDiary : gatheringDiaryEntities) {
-			Optional<GatheringExhEntity> gatheringExhEntity = gatheringExhRepository.findByGatherExhId(
-				gatheringDiary.getGatherExhId());
-			if (gatheringExhEntity.isEmpty()) {
-				continue;
-			}
-			int countExh = countDiary.get(gatheringExhEntity.get().getExhId()) == null ? 0 :
-				countDiary.get(gatheringExhEntity.get().getExhId());
-			Double sumExhRate = sumDiaryRate.get(gatheringExhEntity.get().getExhId()) == null ? 0.0 :
-				sumDiaryRate.get(gatheringExhEntity.get().getExhId());
-			countDiary.put(gatheringExhEntity.get().getExhId(), countExh + 1);
-			sumDiaryRate.put(gatheringExhEntity.get().getExhId(), sumExhRate + gatheringDiary.getRate());
-			// 전시회 중복 제거
-			if (!checkExhs.contains(gatheringExhEntity.get().getExhId())) {
-				checkExhs.add(gatheringExhEntity.get().getExhId());
-			}
-		}
-		// 반환 (친구가 작성한 글들의 평점?으로 구현함.)
+		// 중복 코드를 줄이기 위해 메서드로 분리
+		processExhibitionList(myStoredExhList, countDiary, sumDiaryRate, exhEntityHashMap);
+		processExhibitionList(myStoredGatherExhList, countDiary, sumDiaryRate, exhEntityHashMap);
+
+		List<Long> exhIds = new ArrayList<>(countDiary.keySet());
+		exhIds.sort(Comparator.naturalOrder());
+
 		List<FindMateExhsResult> result = new ArrayList<>();
-		for (Long exhId : checkExhs) {
-			Optional<ExhEntity> exh = exhRepository.findByExhId(exhId);
-			Double averageRate = countDiary.get(exhId) == 0 ? 0.0 : sumDiaryRate.get(exhId) / countDiary.get(exhId);
-
-			if (exh.isPresent()) {
-				String poster = imageTransfer.downloadImage(exh.get().getPoster());
-				result.add(FindMateExhsResult.findMateExhs(exh.get(), poster, averageRate));
-			}
+		for (Long exhId : exhIds) {
+			ExhEntity exh = exhEntityHashMap.get(exhId);
+			double averageRate = countDiary.get(exhId) == 0 ? 0.0 : sumDiaryRate.get(exhId) / countDiary.get(exhId);
+			String poster = imageTransfer.downloadImage(exh.getPoster());
+			result.add(FindMateExhsResult.findMateExhs(exh, poster, averageRate));
 		}
 		return result;
 	}
@@ -180,5 +154,25 @@ public class MateExhsService implements MateExhsReadUseCase {
 
 	private Long getUserId() {
 		return UserIdFilter.getUserId();
+	}
+
+	// 중복 코드를 메서드로 분리
+	private void processExhibitionList(List<Map<String, Object>> exhibitionList, HashMap<Long, Long> countDiary,
+		HashMap<Long, Double> sumDiaryRate, HashMap<Long, ExhEntity> exhEntityHashMap) {
+		for (Map<String, Object> map : exhibitionList) {
+			ExhEntity exh = (ExhEntity)map.get("exhibition");
+			Long count = (Long)map.get("count");
+			Double sumOfRate = (Double)map.get("sumOfRate");
+
+			countDiary.putIfAbsent(exh.getExhId(), 0L);
+			sumDiaryRate.putIfAbsent(exh.getExhId(), 0.0);
+
+			Long countExh = countDiary.get(exh.getExhId());
+			Double sumExhRate = sumDiaryRate.get(exh.getExhId());
+
+			countDiary.put(exh.getExhId(), countExh + count);
+			sumDiaryRate.put(exh.getExhId(), sumExhRate + sumOfRate);
+			exhEntityHashMap.put(exh.getExhId(), exh);
+		}
 	}
 }

--- a/src/main/java/klieme/artdiary/mydiarys/data_access/repository/MydiaryRepoCustom.java
+++ b/src/main/java/klieme/artdiary/mydiarys/data_access/repository/MydiaryRepoCustom.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import com.querydsl.core.Tuple;
 
 public interface MydiaryRepoCustom {
-	List<Map<String, Object>> sumRateByUserExhId(Long userId);
+	List<Map<String, Object>> sumRateByUserExhId(Long userId, Boolean withMate);
 
 	List<Tuple> getMyDiaryListInSoloWithJoin(Long userId, Long exhId);
 

--- a/src/main/java/klieme/artdiary/mydiarys/data_access/repository/MydiaryRepoCustomImpl.java
+++ b/src/main/java/klieme/artdiary/mydiarys/data_access/repository/MydiaryRepoCustomImpl.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -20,10 +21,15 @@ public class MydiaryRepoCustomImpl implements MydiaryRepoCustom {
 	private final JPAQueryFactory query;
 
 	@Override
-	public List<Map<String, Object>> sumRateByUserExhId(Long userId) {
+	public List<Map<String, Object>> sumRateByUserExhId(Long userId, Boolean withMate) {
 		QMydiaryEntity myDiary = QMydiaryEntity.mydiaryEntity;
 		QUserExhEntity userExh = QUserExhEntity.userExhEntity;
 		QExhEntity exh = QExhEntity.exhEntity;
+		BooleanBuilder builder = new BooleanBuilder();
+
+		if (withMate) {
+			builder.and(myDiary.diaryPrivate.eq(true));
+		}
 
 		List<Tuple> tuples = query
 			.select(myDiary.rate.sum(), myDiary.count(), exh)
@@ -31,7 +37,7 @@ public class MydiaryRepoCustomImpl implements MydiaryRepoCustom {
 			.leftJoin(userExh).on(myDiary.userExhId.eq(userExh.userExhId))
 			.leftJoin(exh).on(userExh.exhId.eq(exh.exhId))
 			.fetchJoin()
-			.where(userExh.userId.eq(userId))
+			.where(userExh.userId.eq(userId), builder)
 			.groupBy(userExh.exhId)
 			.fetch();
 

--- a/src/main/java/klieme/artdiary/myexhs/service/MyExhsService.java
+++ b/src/main/java/klieme/artdiary/myexhs/service/MyExhsService.java
@@ -57,9 +57,9 @@ public class MyExhsService implements MyExhsReadUseCase, MyExhsOperationUseCase 
 	public List<MyExhsReadUseCase.FindMyExhsResult> getMyExhsList() throws IOException {
 		Long userId = getUserId();
 		// 1. 혼자 방문한 전시회들의 기록 평점 구하기
-		List<Map<String, Object>> myStoredExhList = mydiaryRepository.sumRateByUserExhId(userId);
+		List<Map<String, Object>> myStoredExhList = mydiaryRepository.sumRateByUserExhId(userId, false);
 		// 2. 모임에서 갔다온 전시회들의 내가 작성한 기록 평점 구하기
-		List<Map<String, Object>> myStoredGatherExhList = gatheringRepository.sumRateByGatherExhId(userId);
+		List<Map<String, Object>> myStoredGatherExhList = gatheringRepository.sumRateByGatherExhId(userId, false);
 
 		//
 		HashMap<Long, Long> countDiary = new HashMap<>(); // 전시회에 대한 기록 개수


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #160 
<br/>

## ⚙️ 변경 사항 

전시 메이트의 공개된 기록이 있는 전시회 목록 데이터 요청 시 querydsl 사용으로 변경

<br/>

## 💦 변경한 이유

- 중첩 for문을 사용한 데이터가 많아질 경우 요청에 대한 응답이 너무 느려져서
- 네트워크가 느릴 경우 프론트엔드가 데이터를 받지 못하는 일이 많아짐.
- 중첩 for문을 사용하여 데이터를 조회하는 방법 대신 querydsl을 사용하여 쿼린 조인하는 방법을 선택하여 쿼리 수도 줄이고 
-  for문을 실행하는 시간도 줄일 수 있었음.

<br/>

## 💻 테스트 사항

- 1차적으로 postman으로 수정한 코드가 정상 응답을 하는지 확인
- 2차적으로 프론트엔드와 연결하여 2가지 네트워크 상황에서 테스트 확인

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
