### PR TITLE
[refactor] 사용자가 등록한 전시회를 포함한 전시회 리스트 반환 순서 추가

### DIFF
--- a/src/main/java/klieme/artdiary/exhibition/data_access/entity/ExhEntity.java
+++ b/src/main/java/klieme/artdiary/exhibition/data_access/entity/ExhEntity.java
@@ -57,4 +57,17 @@ public class ExhEntity {
 		this.poster = poster;
 		this.art = art;
 	}
+
+	public void updateExhEntity(ExhEntity exhEntity) {
+		this.exhName = exhEntity.getExhName();
+		this.gallery = exhEntity.getGallery();
+		this.exhPeriodStart = exhEntity.getExhPeriodStart();
+		this.exhPeriodEnd = exhEntity.getExhPeriodEnd();
+		this.painter = exhEntity.getPainter();
+		this.fee = exhEntity.getFee();
+		this.intro = exhEntity.getIntro();
+		this.url = exhEntity.getUrl();
+		this.poster = exhEntity.getPoster();
+		this.art = exhEntity.getArt();
+	}
 }

--- a/src/main/java/klieme/artdiary/exhibition/data_access/entity/RegExhEntity.java
+++ b/src/main/java/klieme/artdiary/exhibition/data_access/entity/RegExhEntity.java
@@ -30,6 +30,8 @@ public class RegExhEntity {
 	private Long regExhId;
 	@Column(name = "user_id")
 	private Long userId;
+	@Column(name = "exh_id")
+	private Long exhId;
 	@Column(name = "reg_exh_name", nullable = false)
 	private String regExhName;
 	@Column(name = "reg_gallery")
@@ -58,11 +60,12 @@ public class RegExhEntity {
 	private Boolean regState;
 
 	@Builder
-	public RegExhEntity(Long regExhId, Long userId, String regExhName, String regGallery, LocalDate regExhPeriodStart,
-		LocalDate regExhPeriodEnd, String regPainter, Integer regFee, String regIntro, String regUrl, String regPoster,
-		String regArt, LocalDateTime regDate, String regComment, Boolean regState) {
+	public RegExhEntity(Long regExhId, Long userId, Long exhId, String regExhName, String regGallery,
+		LocalDate regExhPeriodStart, LocalDate regExhPeriodEnd, String regPainter, Integer regFee, String regIntro,
+		String regUrl, String regPoster, String regArt, LocalDateTime regDate, String regComment, Boolean regState) {
 		this.regExhId = regExhId;
 		this.userId = userId;
+		this.exhId = exhId;
 		this.regExhName = regExhName;
 		this.regGallery = regGallery;
 		this.regExhPeriodStart = regExhPeriodStart;
@@ -123,6 +126,7 @@ public class RegExhEntity {
 	}
 
 	public void updateByAdmin(RegExhEntity newRegExh) {
+		this.exhId = newRegExh.getExhId();
 		this.regExhName = newRegExh.getRegExhName();
 		this.regGallery = newRegExh.getRegGallery();
 		this.regExhPeriodStart = newRegExh.getRegExhPeriodStart();

--- a/src/main/java/klieme/artdiary/exhibition/data_access/repository/ExhRepoCustom.java
+++ b/src/main/java/klieme/artdiary/exhibition/data_access/repository/ExhRepoCustom.java
@@ -2,13 +2,13 @@ package klieme.artdiary.exhibition.data_access.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
-import klieme.artdiary.exhibition.data_access.entity.ExhEntity;
 import klieme.artdiary.exhibition.enums.ExhField;
 import klieme.artdiary.exhibition.enums.ExhPrice;
 import klieme.artdiary.exhibition.enums.ExhState;
 
 public interface ExhRepoCustom {
-	List<ExhEntity> searchExhList(String searchName, List<ExhField> fieldList, ExhPrice price, List<ExhState> stateList,
-		LocalDate date);
+	List<Map<String, Object>> searchExhList(String searchName, List<ExhField> fieldList, ExhPrice price,
+		List<ExhState> stateList, LocalDate date, Long userId);
 }

--- a/src/main/java/klieme/artdiary/exhibition/data_access/repository/ExhRepoCustomImpl.java
+++ b/src/main/java/klieme/artdiary/exhibition/data_access/repository/ExhRepoCustomImpl.java
@@ -1,9 +1,15 @@
 package klieme.artdiary.exhibition.data_access.repository;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import klieme.artdiary.exhibition.data_access.entity.ExhEntity;
@@ -11,6 +17,7 @@ import klieme.artdiary.exhibition.data_access.entity.QExhEntity;
 import klieme.artdiary.exhibition.enums.ExhField;
 import klieme.artdiary.exhibition.enums.ExhPrice;
 import klieme.artdiary.exhibition.enums.ExhState;
+import klieme.artdiary.favoriteexh.data_access.entity.QFavoriteExhEntity;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -18,10 +25,10 @@ public class ExhRepoCustomImpl implements ExhRepoCustom {
 	private final JPAQueryFactory query;
 
 	@Override
-	public List<ExhEntity> searchExhList(String searchName, List<ExhField> fieldList, ExhPrice price,
-		List<ExhState> stateList,
-		LocalDate date) {
+	public List<Map<String, Object>> searchExhList(String searchName, List<ExhField> fieldList, ExhPrice price,
+		List<ExhState> stateList, LocalDate date, Long userId) {
 		QExhEntity exh = QExhEntity.exhEntity;
+		QFavoriteExhEntity favoriteExh = QFavoriteExhEntity.favoriteExhEntity;
 		BooleanBuilder builder = new BooleanBuilder();
 
 		if (searchName != null) {
@@ -48,7 +55,7 @@ public class ExhRepoCustomImpl implements ExhRepoCustom {
 				builder.and(exh.fee.loe(20000)); // fee <= 20000
 			}
 		}
-		if (stateList != null || date != null) {
+		if ((stateList != null && !stateList.isEmpty()) || date != null) {
 			LocalDate now = date != null ? date : LocalDate.now();
 
 			if (date != null) {
@@ -71,9 +78,39 @@ public class ExhRepoCustomImpl implements ExhRepoCustom {
 				}
 				builder.and(stateListBuilder);
 			}
+		} else {
+			BooleanBuilder stateBuilder = new BooleanBuilder();
+			LocalDate now = LocalDate.now();
+
+			stateBuilder.and(exh.exhPeriodStart.loe(now)); // start <= now
+			stateBuilder.and(exh.exhPeriodEnd.goe(now)); // end >= now
+			builder.and(stateBuilder);
 		}
-		return query.selectFrom(exh)
+		List<Tuple> tuples = query.select(exh,
+				new CaseBuilder()
+					.when(
+						JPAExpressions.selectOne()
+							.from(favoriteExh)
+							.where(favoriteExh.favoriteExhId.exhId.eq(exh.exhId)
+								.and(favoriteExh.favoriteExhId.userId.eq(userId)))
+							.exists()
+					).then(1)
+					.otherwise(0))
+			.from(exh)
+			.leftJoin(favoriteExh).on(exh.exhId.eq(favoriteExh.favoriteExhId.exhId))
+			.fetchJoin()
 			.where(builder)
+			.groupBy(exh.exhId)
+			.orderBy(exh.count().desc(), exh.exhPeriodStart.desc())
 			.fetch();
+		List<Map<String, Object>> result = new ArrayList<>();
+
+		for (Tuple tuple : tuples) {
+			Map<String, Object> row = new HashMap<>();
+			row.put("exhibition", tuple.get(0, ExhEntity.class));
+			row.put("haveFavoriteByUser", tuple.get(1, Boolean.class));
+			result.add(row);
+		}
+		return result;
 	}
 }

--- a/src/main/java/klieme/artdiary/exhibition/data_access/repository/RegExhCustom.java
+++ b/src/main/java/klieme/artdiary/exhibition/data_access/repository/RegExhCustom.java
@@ -5,4 +5,6 @@ import java.util.Map;
 
 public interface RegExhCustom {
 	List<Map<String, Object>> getRegExhListByAdmin();
+
+	Map<String, Object> getRegExhWithExhByAdmin(Long regExhId);
 }

--- a/src/main/java/klieme/artdiary/exhibition/data_access/repository/RegExhCustomImpl.java
+++ b/src/main/java/klieme/artdiary/exhibition/data_access/repository/RegExhCustomImpl.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import klieme.artdiary.exhibition.data_access.entity.ExhEntity;
+import klieme.artdiary.exhibition.data_access.entity.QExhEntity;
 import klieme.artdiary.exhibition.data_access.entity.QRegExhEntity;
 import klieme.artdiary.exhibition.data_access.entity.RegExhEntity;
 import klieme.artdiary.user.data_access.entity.QUserEntity;
@@ -40,5 +42,27 @@ public class RegExhCustomImpl implements RegExhCustom {
 			results.add(row);
 		}
 		return results;
+	}
+
+	@Override
+	public Map<String, Object> getRegExhWithExhByAdmin(Long regExhId) {
+		QRegExhEntity regExh = QRegExhEntity.regExhEntity;
+		QExhEntity exh = QExhEntity.exhEntity;
+
+		Tuple tuple = query
+			.select(regExh, exh)
+			.from(regExh)
+			.leftJoin(exh).on(regExh.exhId.eq(exh.exhId))
+			.fetchJoin()
+			.where(regExh.regExhId.eq(regExhId))
+			.fetchFirst();
+
+		Map<String, Object> result = new HashMap<>();
+
+		if (tuple != null) {
+			result.put("regExhEntity", tuple.get(0, RegExhEntity.class));
+			result.put("exhEntity", tuple.get(1, ExhEntity.class));
+		}
+		return result;
 	}
 }

--- a/src/main/java/klieme/artdiary/exhibition/service/ExhService.java
+++ b/src/main/java/klieme/artdiary/exhibition/service/ExhService.java
@@ -3,7 +3,6 @@ package klieme.artdiary.exhibition.service;
 import static klieme.artdiary.common.FormatDate.*;
 import static klieme.artdiary.common.SecurityUtil.*;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -17,9 +16,6 @@ import klieme.artdiary.common.api.ArtDiaryException;
 import klieme.artdiary.common.api.MessageType;
 import klieme.artdiary.exhibition.data_access.entity.ExhEntity;
 import klieme.artdiary.exhibition.data_access.repository.ExhRepository;
-import klieme.artdiary.exhibition.enums.ExhField;
-import klieme.artdiary.exhibition.enums.ExhPrice;
-import klieme.artdiary.exhibition.enums.ExhState;
 import klieme.artdiary.exhibition.info.StoredListOfDate;
 import klieme.artdiary.favoriteexh.data_access.entity.FavoriteExhEntity;
 import klieme.artdiary.favoriteexh.data_access.entity.FavoriteExhId;
@@ -41,8 +37,7 @@ public class ExhService implements ExhOperationUseCase, ExhReadUseCase {
 
 	@Autowired
 	public ExhService(ExhRepository exhRepository, FavoriteExhRepository favoriteExhRepository,
-		ExhVisitRepository exhVisitRepository,
-		DiaryRepository diaryRepository) {
+		ExhVisitRepository exhVisitRepository, DiaryRepository diaryRepository) {
 		this.exhRepository = exhRepository;
 		this.favoriteExhRepository = favoriteExhRepository;
 		this.exhVisitRepository = exhVisitRepository;
@@ -107,12 +102,22 @@ public class ExhService implements ExhOperationUseCase, ExhReadUseCase {
 
 	@Override
 	public List<FindExhResult> getExhList(ExhListFindQuery query) {
+		/* api 요청 옵션에 전시회 진행 상황이 포함되어있으면 해당 진행 상황 적용.
+		 * 옵션에 진행 상황이 없으면 "현재 진행 중"인 전시회 적용.
+		 */
+		/* 전시회 리스트 고정 순서
+		 * 1. 좋아요 많은 순
+		 * 2. 최근에 시작한 순
+		 * */
 		List<FindExhResult> results = new ArrayList<>();
-		List<ExhEntity> exhEntityList = exhRepository.searchExhList(query.getSearchName(), query.getFieldList(),
-			query.getPrice(), query.getStateList(), query.getDate());
+		List<Map<String, Object>> infoList = exhRepository.searchExhList(query.getSearchName(), query.getFieldList(),
+			query.getPrice(), query.getStateList(), query.getDate(), getUserId());
 
-		for (ExhEntity exh : exhEntityList) {
-			results.add(getFindExhResult(exh));
+		for (Map<String, Object> info : infoList) {
+			ExhEntity exhibition = (ExhEntity)info.get("exhibition");
+			Integer haveFavoriteByUser = (Integer)info.get("haveFavoriteByUser");
+
+			results.add(FindExhResult.findByExhForList(exhibition, haveFavoriteByUser == 1));
 		}
 		return results;
 	}
@@ -175,88 +180,78 @@ public class ExhService implements ExhOperationUseCase, ExhReadUseCase {
 		return getCurrentUserEntity().getUserId();
 	}
 
-	private Boolean checkField(ExhField field, ExhEntity exh) {
-		if (field == null) {
-			return true;
-		}
-		if (field == ExhField.OTHER) {
-			if (exh.getArt() == null) { // other && art == null
-				return true;
-			} else { // other && art != null
-				return !exh.getArt().contains(ExhField.PHOTO.label())
-					&& !exh.getArt().contains(ExhField.PAINTING.label())
-					&& !exh.getArt().contains(ExhField.PIECE.label())
-					&& !exh.getArt().contains(ExhField.CRAFTS.label())
-					&& !exh.getArt().contains(ExhField.MEDIA_ART.label());
-			}
-		} else {
-			if (exh.getArt() == null) { // !other && art == null
-				return false;
-			} else { // !other && art != null
-				return exh.getArt().contains(field.label());
-			}
-		}
-	}
-
-	private Boolean checkPrice(ExhPrice price, ExhEntity exh) {
-		if (price == null) {
-			return true;
-		}
-		switch (price) {
-			case ExhPrice.FREE:
-				if (exh.getFee() == 0) {
-					return true;
-				}
-				break;
-			case ExhPrice.PAY:
-				if (exh.getFee() != 0) {
-					return true;
-				}
-				break;
-			default:
-				if (exh.getFee() <= 20000) {
-					return true;
-				}
-		}
-		return false;
-	}
-
-	private Boolean checkState(ExhState state, ExhEntity exh) {
-		if (state == null) {
-			return true;
-		}
-		LocalDate now = LocalDate.now();
-		switch (state) {
-			case ExhState.BEFORE_START:
-				if (exh.getExhPeriodStart().isAfter(now)) {
-					return true;
-				}
-				break;
-			case ExhState.END:
-				if (exh.getExhPeriodEnd().isBefore(now)) {
-					return true;
-				}
-				break;
-			default:
-				if (isProceedExh(exh, now)) {
-					return true;
-				}
-		}
-		return false;
-	}
-
-	private Boolean isProceedExh(ExhEntity exh, LocalDate targetDate) {
-		return exh.getExhPeriodStart().isEqual(targetDate) || exh.getExhPeriodEnd().isEqual(targetDate)
-			|| (exh.getExhPeriodStart().isBefore(targetDate) && exh.getExhPeriodEnd().isAfter(targetDate));
-	}
-
-	private FindExhResult getFindExhResult(ExhEntity exh) {
-		// 전시회 좋아요 여부 구현
-		Optional<FavoriteExhEntity> favoriteExh = favoriteExhRepository.findByFavoriteExhId(FavoriteExhId.builder()
-			.userId(getUserId())
-			.exhId(exh.getExhId())
-			.build());
-		boolean isFavoriteExh = favoriteExh.isPresent();
-		return FindExhResult.findByExhForList(exh, isFavoriteExh);
-	}
+	// private Boolean checkField(ExhField field, ExhEntity exh) {
+	// 	if (field == null) {
+	// 		return true;
+	// 	}
+	// 	if (field == ExhField.OTHER) {
+	// 		if (exh.getArt() == null) { // other && art == null
+	// 			return true;
+	// 		} else { // other && art != null
+	// 			return !exh.getArt().contains(ExhField.PHOTO.label())
+	// 				&& !exh.getArt().contains(ExhField.PAINTING.label())
+	// 				&& !exh.getArt().contains(ExhField.PIECE.label())
+	// 				&& !exh.getArt().contains(ExhField.CRAFTS.label())
+	// 				&& !exh.getArt().contains(ExhField.MEDIA_ART.label());
+	// 		}
+	// 	} else {
+	// 		if (exh.getArt() == null) { // !other && art == null
+	// 			return false;
+	// 		} else { // !other && art != null
+	// 			return exh.getArt().contains(field.label());
+	// 		}
+	// 	}
+	// }
+	//
+	// private Boolean checkPrice(ExhPrice price, ExhEntity exh) {
+	// 	if (price == null) {
+	// 		return true;
+	// 	}
+	// 	switch (price) {
+	// 		case ExhPrice.FREE:
+	// 			if (exh.getFee() == 0) {
+	// 				return true;
+	// 			}
+	// 			break;
+	// 		case ExhPrice.PAY:
+	// 			if (exh.getFee() != 0) {
+	// 				return true;
+	// 			}
+	// 			break;
+	// 		default:
+	// 			if (exh.getFee() <= 20000) {
+	// 				return true;
+	// 			}
+	// 	}
+	// 	return false;
+	// }
+	//
+	// private Boolean checkState(ExhState state, ExhEntity exh) {
+	// 	if (state == null) {
+	// 		return true;
+	// 	}
+	// 	LocalDate now = LocalDate.now();
+	// 	switch (state) {
+	// 		case ExhState.BEFORE_START:
+	// 			if (exh.getExhPeriodStart().isAfter(now)) {
+	// 				return true;
+	// 			}
+	// 			break;
+	// 		case ExhState.END:
+	// 			if (exh.getExhPeriodEnd().isBefore(now)) {
+	// 				return true;
+	// 			}
+	// 			break;
+	// 		default:
+	// 			if (isProceedExh(exh, now)) {
+	// 				return true;
+	// 			}
+	// 	}
+	// 	return false;
+	// }
+	//
+	// private Boolean isProceedExh(ExhEntity exh, LocalDate targetDate) {
+	// 	return exh.getExhPeriodStart().isEqual(targetDate) || exh.getExhPeriodEnd().isEqual(targetDate)
+	// 		|| (exh.getExhPeriodStart().isBefore(targetDate) && exh.getExhPeriodEnd().isAfter(targetDate));
+	// }
 }

--- a/src/main/java/klieme/artdiary/exhibition/service/RegExhService.java
+++ b/src/main/java/klieme/artdiary/exhibition/service/RegExhService.java
@@ -13,7 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import klieme.artdiary.common.api.ArtDiaryException;
 import klieme.artdiary.common.api.MessageType;
+import klieme.artdiary.exhibition.data_access.entity.ExhEntity;
 import klieme.artdiary.exhibition.data_access.entity.RegExhEntity;
+import klieme.artdiary.exhibition.data_access.repository.ExhRepository;
 import klieme.artdiary.exhibition.data_access.repository.RegExhRepository;
 import klieme.artdiary.user.data_access.entity.UserEntity;
 import klieme.artdiary.user.enums.RoleType;
@@ -21,10 +23,12 @@ import klieme.artdiary.user.enums.RoleType;
 @Service
 public class RegExhService implements RegExhOperationUseCase, RegExhReadUseCase {
 	private final RegExhRepository regExhRepository;
+	private final ExhRepository exhRepository;
 
 	@Autowired
-	public RegExhService(RegExhRepository regExhRepository) {
+	public RegExhService(RegExhRepository regExhRepository, ExhRepository exhRepository) {
 		this.regExhRepository = regExhRepository;
+		this.exhRepository = exhRepository;
 	}
 
 	@Transactional
@@ -169,9 +173,36 @@ public class RegExhService implements RegExhOperationUseCase, RegExhReadUseCase 
 			throw new ArtDiaryException(MessageType.FORBIDDEN);
 		}
 
-		RegExhEntity regExhEntity = regExhRepository.findByRegExhId(command.getRegExhId())
-			.orElseThrow(() -> new ArtDiaryException(MessageType.NOT_FOUND));
+		Map<String, Object> regExhInfo = regExhRepository.getRegExhWithExhByAdmin(command.getRegExhId());
+
+		if (regExhInfo.isEmpty()) {
+			throw new ArtDiaryException(MessageType.NOT_FOUND);
+		}
+		RegExhEntity regExhEntity = (RegExhEntity)regExhInfo.get("regExhEntity");
+		ExhEntity exhEntity = (ExhEntity)regExhInfo.get("exhEntity");
+
+		// 관리자가 승인한 전시회를 전시회 테이블에 추가
+		ExhEntity updateExhEntity = ExhEntity.builder()
+			.exhName(command.getRegExhName())
+			.gallery(command.getRegGallery())
+			.exhPeriodStart(command.getRegExhPeriodStart())
+			.exhPeriodEnd(command.getRegExhPeriodEnd())
+			.painter(command.getRegPainter())
+			.fee(command.getRegFee())
+			.intro(command.getRegIntro())
+			.url(command.getRegUrl())
+			.poster(command.getRegPoster())
+			.art(command.getRegArt())
+			.build();
+		if (exhEntity == null) {
+			exhEntity = updateExhEntity;
+		} else {
+			exhEntity.updateExhEntity(updateExhEntity);
+		}
+		exhRepository.save(exhEntity);
+		// 사용자가 요청한 전시회를 관리자가 승인
 		regExhEntity.updateByAdmin(RegExhEntity.builder()
+			.exhId(exhEntity.getExhId())
 			.regExhName(command.getRegExhName())
 			.regGallery(command.getRegGallery())
 			.regExhPeriodStart(command.getRegExhPeriodStart())


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #238 
<br/>

## ⚙️ 변경 사항 

사용자가 등록한 전시회를 포함한 전시회 리스트 반환 순서 추가
 - reg_exh 엔티티에 exh_id 참조를 추가하고, 관리자가 등록 승인하면 exhibition 테이블에 데이터 추가되도록 수정

<br/>

## 💦 변경한 이유

- 사용자가 등록한 전시회를 포함한 전시회 리스트 반환 순서 추가

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
