### PR TITLE
[refactor] 전시 메이트 검색 시 메이트가 아닌 유저 리스트와 이미 친구인 유저 리스트로 반환하고 닉네임 순으로 정렬…

### DIFF
--- a/src/main/java/klieme/artdiary/mate/data_access/repository/MateRepoCustom.java
+++ b/src/main/java/klieme/artdiary/mate/data_access/repository/MateRepoCustom.java
@@ -1,9 +1,12 @@
 package klieme.artdiary.mate.data_access.repository;
 
 import java.util.List;
+import java.util.Map;
 
 import klieme.artdiary.user.data_access.entity.UserEntity;
 
 public interface MateRepoCustom {
 	List<UserEntity> getMyMateListByFromUserId(Long fromUserId);
+
+	List<Map<String, Object>> getMateListForSearch(Long fromUserId, String nickname);
 }

--- a/src/main/java/klieme/artdiary/mate/data_access/repository/MateRepoCustomImpl.java
+++ b/src/main/java/klieme/artdiary/mate/data_access/repository/MateRepoCustomImpl.java
@@ -1,7 +1,12 @@
 package klieme.artdiary.mate.data_access.repository;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import klieme.artdiary.mate.data_access.entity.QMateEntity;
@@ -26,5 +31,35 @@ public class MateRepoCustomImpl implements MateRepoCustom {
 			.where(mate.fromUserId.eq(fromUserId))
 			.orderBy(user.nickname.asc())
 			.fetch();
+	}
+
+	@Override
+	public List<Map<String, Object>> getMateListForSearch(Long fromUserId, String nickname) {
+		QMateEntity mate = QMateEntity.mateEntity;
+		QUserEntity user = QUserEntity.userEntity;
+
+		List<Tuple> tuples = query
+			.select(user, new CaseBuilder()
+				.when(mate.mateId.isNull()).then(false)
+				.otherwise(true))
+			.from(user)
+			.leftJoin(mate).on(user.userId.eq(mate.toUserId), mate.fromUserId.eq(fromUserId))
+			.fetchJoin()
+			.where(user.nickname.toLowerCase().notLike("%kakao_%")
+				, user.nickname.toLowerCase().notLike("%google_%")
+				, user.nickname.toLowerCase().notLike("%naver_%")
+				, user.nickname.contains(nickname))
+			.orderBy(user.nickname.asc())
+			.fetch();
+
+		List<Map<String, Object>> results = new ArrayList<>();
+
+		for (Tuple tuple : tuples) {
+			Map<String, Object> row = new HashMap<>();
+			row.put("userEntity", tuple.get(0, UserEntity.class));
+			row.put("isMate", tuple.get(1, Boolean.class));
+			results.add(row);
+		}
+		return results;
 	}
 }

--- a/src/main/java/klieme/artdiary/mate/service/MateReadUseCase.java
+++ b/src/main/java/klieme/artdiary/mate/service/MateReadUseCase.java
@@ -10,7 +10,23 @@ import lombok.ToString;
 public interface MateReadUseCase {
 	List<FindMateResult> getMateList();
 
-	List<FindMateResult> searchNewMate(String nickname);
+	FindIsMateResult searchNewMate(String nickname);
+
+	@Getter
+	@ToString
+	@Builder
+	class FindIsMateResult {
+		private final List<FindMateResult> alreadyMate;
+		private final List<FindMateResult> notMate;
+
+		public static FindIsMateResult findByGatheringMate(List<FindMateResult> alreadyMate,
+			List<FindMateResult> notMate) {
+			return FindIsMateResult.builder()
+				.alreadyMate(alreadyMate)
+				.notMate(notMate)
+				.build();
+		}
+	}
 
 	@Getter
 	@ToString

--- a/src/main/java/klieme/artdiary/mate/service/MateService.java
+++ b/src/main/java/klieme/artdiary/mate/service/MateService.java
@@ -4,6 +4,7 @@ import static klieme.artdiary.common.SecurityUtil.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,25 +42,23 @@ public class MateService implements MateReadUseCase, MateOperationUseCase {
 	}
 
 	@Override
-	public List<MateReadUseCase.FindMateResult> searchNewMate(String nickname) {
+	public FindIsMateResult searchNewMate(String nickname) {
 		// 가져오기& 이미 내 전시메이트인 경우 보여주지 않기
-		List<MateReadUseCase.FindMateResult> results = new ArrayList<>();
-		List<MateEntity> mates = mateRepository.findByFromUserId(getUserId()); //나의 전시메이트 목록
-		List<UserEntity> users = userRepository.findByNicknameContainingIgnoreCase(nickname);
+		List<Map<String, Object>> mateQuery = mateRepository.getMateListForSearch(getUserId(), nickname);
+		List<FindMateResult> alreadyMate = new ArrayList<>();
+		List<FindMateResult> notMate = new ArrayList<>();
 
-		for (UserEntity user : users) {
+		for (Map<String, Object> query : mateQuery) {
+			UserEntity userEntity = (UserEntity)query.get("userEntity");
+			Boolean isMate = (Boolean)query.get("isMate");
 
-			Optional<MateEntity> filterUser = mates.stream()
-				.filter(m -> m.getToUserId().equals(user.getUserId()))
-				.findAny();
-
-			if (filterUser.isEmpty() && !user.getUserId().equals(getUserId())) {
-				results.add(MateReadUseCase.FindMateResult.findByGatheringExhs(user));
+			if (isMate) {
+				alreadyMate.add(FindMateResult.findByGatheringExhs(userEntity));
+			} else {
+				notMate.add(FindMateResult.findByGatheringExhs(userEntity));
 			}
-
 		}
-
-		return results;
+		return FindIsMateResult.findByGatheringMate(alreadyMate, notMate);
 	}
 
 	@Override

--- a/src/main/java/klieme/artdiary/mate/ui/controller/MateController.java
+++ b/src/main/java/klieme/artdiary/mate/ui/controller/MateController.java
@@ -16,6 +16,7 @@ import jakarta.validation.Valid;
 import klieme.artdiary.mate.service.MateOperationUseCase;
 import klieme.artdiary.mate.service.MateReadUseCase;
 import klieme.artdiary.mate.ui.request_body.MateRequest;
+import klieme.artdiary.mate.ui.view.MateSearchView;
 import klieme.artdiary.mate.ui.view.MateView;
 import lombok.extern.slf4j.Slf4j;
 
@@ -77,17 +78,14 @@ public class MateController {
 	 * "/mates/search?nickname=[]"
 	 */
 	@GetMapping("/search")
-	public ResponseEntity<List<MateView>> searchNewMate(
+	public ResponseEntity<MateSearchView> searchNewMate(
 		@RequestParam(name = "nickname", required = false) String nickname) {
 		log.info("[전시 메이트 추가할 때 닉네임 검색]");
 
 		List<MateView> results = new ArrayList<>();
 
-		List<MateReadUseCase.FindMateResult> mateList = mateReadUseCase.searchNewMate(nickname);
-		for (MateReadUseCase.FindMateResult mate : mateList) {
-			results.add(MateView.builder().result(mate).build());
-		}
-		return ResponseEntity.ok(results);
-	}
+		MateReadUseCase.FindIsMateResult result = mateReadUseCase.searchNewMate(nickname);
 
+		return ResponseEntity.ok(MateSearchView.builder().result(result).build());
+	}
 }

--- a/src/main/java/klieme/artdiary/mate/ui/view/MateSearchView.java
+++ b/src/main/java/klieme/artdiary/mate/ui/view/MateSearchView.java
@@ -1,0 +1,24 @@
+package klieme.artdiary.mate.ui.view;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import klieme.artdiary.mate.service.MateReadUseCase;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MateSearchView {
+	private final List<MateReadUseCase.FindMateResult> alreadyMate;
+	private final List<MateReadUseCase.FindMateResult> notMate;
+
+	@Builder
+	public MateSearchView(MateReadUseCase.FindIsMateResult result) {
+		this.alreadyMate = result.getAlreadyMate();
+		this.notMate = result.getNotMate();
+	}
+}


### PR DESCRIPTION
…로 변경

## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #272 
<br/>

## ⚙️ 변경 사항 

전시 메이트 검색 시 메이트가 아닌 유저 리스트와 이미 친구인 유저 리스트로 반환하고 닉네임 순으로 정렬로 변경

<br/>

## 💦 변경한 이유

- 전시 메이트 검색 시 메이트가 아닌 유저 리스트와 이미 친구인 유저 리스트로 반환하고 닉네임 순으로 정렬로 변경

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
