### PR TITLE
[refactor] 모임 메이트 검색 시 새로 추가할 유저 리스트와 이미 포함된 유저 리스트로 반환하고 닉네임 순으로 정렬로 변경

### DIFF
--- a/src/main/java/klieme/artdiary/gathering/data_access/repository/GatheringMateRepoCustom.java
+++ b/src/main/java/klieme/artdiary/gathering/data_access/repository/GatheringMateRepoCustom.java
@@ -1,10 +1,12 @@
 package klieme.artdiary.gathering.data_access.repository;
 
 import java.util.List;
+import java.util.Map;
 
 import klieme.artdiary.gathering.data_access.entity.GatheringEntity;
 
 public interface GatheringMateRepoCustom {
-
 	List<GatheringEntity> getGatheringListByRecentVisitDate(Long userId);
+
+	List<Map<String, Object>> getGatheringMateListForSearch(Long gatherId, Long userId, String nickname);
 }

--- a/src/main/java/klieme/artdiary/gathering/data_access/repository/GatheringMateRepoCustomImpl.java
+++ b/src/main/java/klieme/artdiary/gathering/data_access/repository/GatheringMateRepoCustomImpl.java
@@ -1,13 +1,21 @@
 package klieme.artdiary.gathering.data_access.repository;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import klieme.artdiary.gathering.data_access.entity.GatheringEntity;
 import klieme.artdiary.gathering.data_access.entity.QGatheringEntity;
 import klieme.artdiary.gathering.data_access.entity.QGatheringMateEntity;
+import klieme.artdiary.mate.data_access.entity.QMateEntity;
 import klieme.artdiary.record_data_access.entity.QExhVisitEntity;
+import klieme.artdiary.user.data_access.entity.QUserEntity;
+import klieme.artdiary.user.data_access.entity.UserEntity;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -31,5 +39,41 @@ public class GatheringMateRepoCustomImpl implements GatheringMateRepoCustom {
 			.groupBy(exhVisit.gatherId)
 			.orderBy(exhVisit.visitDate.max().desc())
 			.fetch();
+	}
+
+	@Override
+	public List<Map<String, Object>> getGatheringMateListForSearch(Long gatherId, Long userId, String nickname) {
+		QMateEntity mate = QMateEntity.mateEntity;
+		QUserEntity user = QUserEntity.userEntity;
+		QGatheringMateEntity gatheringMate = QGatheringMateEntity.gatheringMateEntity;
+
+		List<Tuple> tuples = query
+			.select(user, new CaseBuilder()
+				.when(gatheringMate.gatheringMateId.gatherId.isNull()).then(false)
+				.otherwise(true))
+			.from(mate)
+			.leftJoin(gatheringMate)
+			.on(mate.toUserId.eq(gatheringMate.gatheringMateId.userId),
+				gatheringMate.gatheringMateId.gatherId.eq(gatherId))
+			.leftJoin(user)
+			.on(mate.toUserId.eq(user.userId))
+			.fetchJoin()
+			.where(mate.fromUserId.eq(userId)
+				, user.nickname.toLowerCase().notLike("%kakao_%")
+				, user.nickname.toLowerCase().notLike("%google_%")
+				, user.nickname.toLowerCase().notLike("%naver_%")
+				, user.nickname.contains(nickname))
+			.orderBy(user.nickname.asc())
+			.fetch();
+
+		List<Map<String, Object>> results = new ArrayList<>();
+
+		for (Tuple tuple : tuples) {
+			Map<String, Object> row = new HashMap<>();
+			row.put("userEntity", tuple.get(0, UserEntity.class));
+			row.put("isGatheringMate", tuple.get(1, Boolean.class));
+			results.add(row);
+		}
+		return results;
 	}
 }

--- a/src/main/java/klieme/artdiary/gathering/service/GatheringReadUseCase.java
+++ b/src/main/java/klieme/artdiary/gathering/service/GatheringReadUseCase.java
@@ -25,7 +25,7 @@ public interface GatheringReadUseCase {
 
 	FindGatheringDetailInfoResult getGatheringDetailInfo(GatheringDetailInfoFindQuery query);
 
-	List<FindGatheringMatesResult> searchNicknameNotInGathering(GatheringNicknameFindQuery query);
+	FindIsGatheringMateResult searchNicknameNotInGathering(GatheringNicknameFindQuery query);
 
 	@EqualsAndHashCode
 	@Getter
@@ -125,6 +125,22 @@ public interface GatheringReadUseCase {
 				.visitDate(changeDateFormat(exhVisit.getVisitDate()))
 				.exhName(exh.getExhName())
 				.exhVisitId(diary.getExhVisitId())
+				.build();
+		}
+	}
+
+	@Getter
+	@ToString
+	@Builder
+	class FindIsGatheringMateResult {
+		private final List<FindGatheringMatesResult> alreadyMate;
+		private final List<FindGatheringMatesResult> notMate;
+
+		public static FindIsGatheringMateResult findByGatheringMate(List<FindGatheringMatesResult> alreadyMate,
+			List<FindGatheringMatesResult> notMate) {
+			return FindIsGatheringMateResult.builder()
+				.alreadyMate(alreadyMate)
+				.notMate(notMate)
 				.build();
 		}
 	}

--- a/src/main/java/klieme/artdiary/gathering/service/GatheringService.java
+++ b/src/main/java/klieme/artdiary/gathering/service/GatheringService.java
@@ -25,8 +25,6 @@ import klieme.artdiary.gathering.data_access.repository.GatheringMateRepository;
 import klieme.artdiary.gathering.data_access.repository.GatheringRepository;
 import klieme.artdiary.gathering.info.ExhibitionInfo;
 import klieme.artdiary.gathering.info.MateInfo;
-import klieme.artdiary.mate.data_access.entity.MateEntity;
-import klieme.artdiary.mate.data_access.repository.MateRepository;
 import klieme.artdiary.record_data_access.entity.DiaryEntity;
 import klieme.artdiary.record_data_access.entity.ExhVisitEntity;
 import klieme.artdiary.record_data_access.repository.DiaryRepository;
@@ -40,19 +38,17 @@ public class GatheringService implements GatheringOperationUseCase, GatheringRea
 	private final GatheringMateRepository gatheringMateRepository;
 	private final ExhRepository exhRepository;
 	private final UserRepository userRepository;
-	private final MateRepository mateRepository;
 	private final ExhVisitRepository exhVisitRepository;
 	private final DiaryRepository diaryRepository;
 
 	@Autowired
 	public GatheringService(GatheringRepository gatheringRepository, GatheringMateRepository gatheringMateRepository,
-		ExhRepository exhRepository, UserRepository userRepository, MateRepository mateRepository,
-		ExhVisitRepository exhVisitRepository, DiaryRepository diaryRepository) {
+		ExhRepository exhRepository, UserRepository userRepository, ExhVisitRepository exhVisitRepository,
+		DiaryRepository diaryRepository) {
 		this.gatheringRepository = gatheringRepository;
 		this.gatheringMateRepository = gatheringMateRepository;
 		this.exhRepository = exhRepository;
 		this.userRepository = userRepository;
-		this.mateRepository = mateRepository;
 		this.exhVisitRepository = exhVisitRepository;
 		this.diaryRepository = diaryRepository;
 	}
@@ -297,40 +293,38 @@ public class GatheringService implements GatheringOperationUseCase, GatheringRea
 	}
 
 	@Override
-	public List<FindGatheringMatesResult> searchNicknameNotInGathering(GatheringNicknameFindQuery query) {
-		// 모임 멤버 리스트 조회
-		List<GatheringMateEntity> gatheringMateEntities = gatheringMateRepository.findByGatheringMateIdGatherId(
-			query.getGatherId());
+	public FindIsGatheringMateResult searchNicknameNotInGathering(GatheringNicknameFindQuery query) {
+		Long myUserId = getUserId();
+
 		// 모임에 속해 있는지 확인
-		Optional<GatheringMateEntity> isMember = gatheringMateEntities.stream()
-			.filter(gm -> gm.getGatheringMateId().getUserId().equals(getUserId()))
-			.findAny();
+		Optional<GatheringMateEntity> isMember = gatheringMateRepository.findByGatheringMateId(GatheringMateId.builder()
+			.gatherId(query.getGatherId())
+			.userId(myUserId)
+			.build());
 
 		if (isMember.isEmpty()) {
 			throw new ArtDiaryException(MessageType.NOT_FOUND);
 		}
-		// 요청 nickname에 해당하면서 모임에 속해 있지 않은 유저 필터링
-		// 내 전시 메이트 중에서 확인
-		List<MateEntity> mateEntities = mateRepository.findByFromUserId(getUserId());
-		List<FindGatheringMatesResult> results = new ArrayList<>();
+		// 내 전시 리스트 중, 이미 모임에 포함된 경우와 아닌 경우로 나눠서 반환하기
+		List<Map<String, Object>> gatheringMateQuery = gatheringMateRepository.getGatheringMateListForSearch(
+			query.getGatherId(), myUserId, query.getNickname());
+		List<FindGatheringMatesResult> alreadyMate = new ArrayList<>();
+		List<FindGatheringMatesResult> notMate = new ArrayList<>();
 
-		for (MateEntity mate : mateEntities) {
-			Optional<UserEntity> user = userRepository.findByUserIdAndNicknameContainingIgnoreCase(mate.getToUserId(),
-				query.getNickname());
+		for (Map<String, Object> gatheringMate : gatheringMateQuery) {
+			UserEntity userEntity = (UserEntity)gatheringMate.get("userEntity");
+			Boolean isMate = (Boolean)gatheringMate.get("isGatheringMate");
 
-			if (user.isPresent()) {
-				Optional<GatheringMateEntity> filterUser = gatheringMateEntities.stream()
-					.filter(gm -> gm.getGatheringMateId().getUserId().equals(user.get().getUserId()))
-					.findAny();
-
-				if (filterUser.isEmpty()) {
-					results.add(FindGatheringMatesResult.findByGatheringMates(user.get()));
-				}
+			if (Objects.equals(myUserId, userEntity.getUserId())) {
+				continue;
+			}
+			if (isMate) {
+				alreadyMate.add(FindGatheringMatesResult.findByGatheringMates(userEntity));
+			} else {
+				notMate.add(FindGatheringMatesResult.findByGatheringMates(userEntity));
 			}
 		}
-		// 이름 순으로 정렬
-		results.sort(Comparator.comparing(FindGatheringMatesResult::getNickname));
-		return results;
+		return FindIsGatheringMateResult.findByGatheringMate(alreadyMate, notMate);
 	}
 
 	@Override

--- a/src/main/java/klieme/artdiary/gathering/ui/controller/GatheringController.java
+++ b/src/main/java/klieme/artdiary/gathering/ui/controller/GatheringController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import klieme.artdiary.gathering.service.GatheringOperationUseCase;
 import klieme.artdiary.gathering.service.GatheringReadUseCase;
 import klieme.artdiary.gathering.ui.request_body.AddExhDateRequest;
@@ -26,6 +25,7 @@ import klieme.artdiary.gathering.ui.request_body.AddGatheringRequest;
 import klieme.artdiary.gathering.ui.view.GatheringDetailInfoView;
 import klieme.artdiary.gathering.ui.view.GatheringDiaryView;
 import klieme.artdiary.gathering.ui.view.GatheringExhView;
+import klieme.artdiary.gathering.ui.view.GatheringMateSearchView;
 import klieme.artdiary.gathering.ui.view.GatheringMateView;
 import klieme.artdiary.gathering.ui.view.GatheringView;
 import lombok.extern.slf4j.Slf4j;
@@ -174,9 +174,9 @@ public class GatheringController {
 	 * /gatherings/:gatherId/search?nickname=[]
 	 */
 	@GetMapping("/{gatherId}/search")
-	public ResponseEntity<List<GatheringMateView>> searchUserForGathering(
+	public ResponseEntity<GatheringMateSearchView> searchUserForGathering(
 		@PathVariable(name = "gatherId") Long gatherId,
-		@NotBlank @RequestParam(name = "nickname") String nickname
+		@RequestParam(name = "nickname", required = false) String nickname
 	) {
 		log.info("[모임 메이트 추가할 때 닉네임 검색]");
 		var query = GatheringReadUseCase.GatheringNicknameFindQuery.builder()
@@ -184,14 +184,9 @@ public class GatheringController {
 			.nickname(nickname)
 			.build();
 		// 비즈니스 로직 호출
-		List<GatheringReadUseCase.FindGatheringMatesResult> results = gatheringReadUseCase.searchNicknameNotInGathering(
+		GatheringReadUseCase.FindIsGatheringMateResult result = gatheringReadUseCase.searchNicknameNotInGathering(
 			query);
-		// 비즈니스 로직 결과값을 view 형식에 맞춰 list로 반환
-		List<GatheringMateView> viewList = new ArrayList<>();
 
-		for (GatheringReadUseCase.FindGatheringMatesResult result : results) {
-			viewList.add(GatheringMateView.builder().result(result).build());
-		}
-		return ResponseEntity.ok(viewList);
+		return ResponseEntity.ok(GatheringMateSearchView.builder().result(result).build());
 	}
 }

--- a/src/main/java/klieme/artdiary/gathering/ui/view/GatheringMateSearchView.java
+++ b/src/main/java/klieme/artdiary/gathering/ui/view/GatheringMateSearchView.java
@@ -1,0 +1,24 @@
+package klieme.artdiary.gathering.ui.view;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import klieme.artdiary.gathering.service.GatheringReadUseCase;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GatheringMateSearchView {
+	private final List<GatheringReadUseCase.FindGatheringMatesResult> alreadyMate;
+	private final List<GatheringReadUseCase.FindGatheringMatesResult> notMate;
+
+	@Builder
+	public GatheringMateSearchView(GatheringReadUseCase.FindIsGatheringMateResult result) {
+		this.alreadyMate = result.getAlreadyMate();
+		this.notMate = result.getNotMate();
+	}
+}

--- a/src/main/java/klieme/artdiary/mate/service/MateService.java
+++ b/src/main/java/klieme/artdiary/mate/service/MateService.java
@@ -5,6 +5,7 @@ import static klieme.artdiary.common.SecurityUtil.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,11 +48,15 @@ public class MateService implements MateReadUseCase, MateOperationUseCase {
 		List<Map<String, Object>> mateQuery = mateRepository.getMateListForSearch(getUserId(), nickname);
 		List<FindMateResult> alreadyMate = new ArrayList<>();
 		List<FindMateResult> notMate = new ArrayList<>();
+		Long myUserId = getUserId();
 
 		for (Map<String, Object> query : mateQuery) {
 			UserEntity userEntity = (UserEntity)query.get("userEntity");
 			Boolean isMate = (Boolean)query.get("isMate");
 
+			if (Objects.equals(myUserId, userEntity.getUserId())) {
+				continue;
+			}
 			if (isMate) {
 				alreadyMate.add(FindMateResult.findByGatheringExhs(userEntity));
 			} else {

--- a/src/main/java/klieme/artdiary/mate/ui/controller/MateController.java
+++ b/src/main/java/klieme/artdiary/mate/ui/controller/MateController.java
@@ -82,8 +82,6 @@ public class MateController {
 		@RequestParam(name = "nickname", required = false) String nickname) {
 		log.info("[전시 메이트 추가할 때 닉네임 검색]");
 
-		List<MateView> results = new ArrayList<>();
-
 		MateReadUseCase.FindIsMateResult result = mateReadUseCase.searchNewMate(nickname);
 
 		return ResponseEntity.ok(MateSearchView.builder().result(result).build());


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #275 
<br/>

## ⚙️ 변경 사항 

모임 메이트 검색 시 새로 추가할 유저 리스트와 이미 포함된 유저 리스트로 반환하고 닉네임 순으로 정렬로 변경

<br/>

## 💦 변경한 이유

- 모임 메이트 검색 시 새로 추가할 유저 리스트와 이미 포함된 유저 리스트로 반환하고 닉네임 순으로 정렬로 변경

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
